### PR TITLE
Updating the build db workflow to run on linux

### DIFF
--- a/workflow-templates/im-build-db-ci.yml
+++ b/workflow-templates/im-build-db-ci.yml
@@ -122,7 +122,7 @@ jobs:
           path-to-lint-config: ./.tsqllintrc # TODO: Update this with the path to your project's .tsllintrc file
 
   build-database:
-    runs-on: [self-hosted, windows-2019]
+    runs-on: [self-hosted, ubuntu-20.04]
     needs: [set-vars, lint-migration-files] # TODO: Remove any jobs you deleted above
     if: ${{ needs.set-vars.outputs.should-skip-remaining-workflow-jobs == 'false' }} # TODO: Remove this if there is no snapshot commit that should cause this step to be skipped.
     steps:
@@ -134,7 +134,7 @@ jobs:
           version: 7.2.0 # This version works with the current version of build-database-ci-action. Newer versions might, but they should be tested.
 
       - name: Build Database
-        uses: im-open/build-database-ci-action@v1.0.7
+        uses: im-open/build-database-ci-action@v2.0.0
         with:
           db-server-name: ${{ env.DB_SERVER_NAME }}
           db-server-port: ${{ env.DB_SERVER_PORT }}
@@ -145,6 +145,9 @@ jobs:
           run-tests: true # TODO: Remove this if your database doesn't have tests.
           nuget-username: ${{ secrets.ARTIFACTORY_USERNAME }} # TODO: If install-mock-db-objects is set to false, this can be removed
           nuget-password: ${{ secrets.ARTIFACTORY_API_KEY }} # TODO: If install-mock-db-objects is set to false, this can be removed
+          # If you need to run this job on Windows runners, then remove db-username and db-password so integrated security will be utilized
+          db-username: sa
+          db-password: ${{ secrets.ACTIONS_RUNNER_MSSQL_SA_PWD }}
 
       #########################################################################################################################
       # The previous three steps are all that most builds will need. They will build your database on the Action Runner and run any tests you have.
@@ -200,7 +203,7 @@ jobs:
       #     snapshot-path: ${{ env.SNAPSHOT_PATH }}
       #     objects-to-increment: '${{ steps.changed-objects.outputs.json }}'
       #     excluded-db-objects: ${{ env.EXCLUDED_DB_SNAPSHOT_OBJECTS }}
-      
+
       # - name: Setup git for snapshot commit
       #   run: |
       #     git config user.name github-actions


### PR DESCRIPTION
For now there is a note that to run on windows you need to use integrated security. I plan on updating the Windows SQL Server installation on the runners to have the same account login creds as the Ubuntu ones so that is no longer necessary. Once that's done I'll update this template again.