### PR TITLE
ARCH-1146 - Remove central logging

### DIFF
--- a/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
+++ b/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
@@ -1,11 +1,11 @@
-# Workflow Code: DeterminedPorcupine_v8    DO NOT REMOVE
-# Purpose: 
-#    Automatically runs a terraform plan against the specified environments and 
+# Workflow Code: DeterminedPorcupine_v9    DO NOT REMOVE
+# Purpose:
+#    Automatically runs a terraform plan against the specified environments and
 #    comments on the PR with the expected changes when commits are pushed to a PR.
 #
-# Frequency: 
+# Frequency:
 #    - This workflow should only be used once per repository
-#   
+#
 # Projects to use this Template with:
 #    - Terraform (Core Template)
 #
@@ -47,12 +47,10 @@ jobs:
       TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
       TF_WORKING_DIR: './${{ matrix.environment }}' # TODO: Verify this directory structure would be correct for your repository
       # The following SSH_* secrets are org-level secrets
-      SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
       SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
       SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
       SSH_DEPLOY_KEY_INFO: |
         [
-          { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
           { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
           { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
         ]

--- a/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
+++ b/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
@@ -1,11 +1,11 @@
-# Workflow Code: IrritableEagle_v16    DO NOT REMOVE
-# Purpose: 
-#    Automatically runs a terraform apply -auto-approve with the changes 
-#    in the PR against the dev environment when a PR is merged to main. 
-#    
+# Workflow Code: IrritableEagle_v17    DO NOT REMOVE
+# Purpose:
+#    Automatically runs a terraform apply -auto-approve with the changes
+#    in the PR against the dev environment when a PR is merged to main.
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    - Terraform (Core Template)
 #
@@ -39,12 +39,10 @@ env:
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   TF_WORKING_DIR: './dev' # TODO: Verify this directory is correct for your repository
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v21    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v22    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform at a specified tag to a specified
 #    environment when someone kicks off the build manually.
@@ -38,12 +38,10 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,10 +1,10 @@
-# Workflow Code: HostileMacaw_v2    DO NOT REMOVE
-# Purpose: 
+# Workflow Code: HostileMacaw_v3    DO NOT REMOVE
+# Purpose:
 #    Destroys all the remote objects for a terraform configuration when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    -  Terraform (Optional Template)
 #
@@ -35,12 +35,10 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-run-tf-import.yml
+++ b/workflow-templates/im-run-tf-import.yml
@@ -1,18 +1,17 @@
-# Workflow Code: DrearyBuck_v5    DO NOT REMOVE
+# Workflow Code: DrearyBuck_v6    DO NOT REMOVE
 
-# Purpose: 
+# Purpose:
 #    Imports a specified resource into the terraform state when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    -  Terraform (Optional Template)
 #
 # TODO Prerequisites:
 #    - If the terraform is still using on-prem-egress-ips, it needs to be switched to network-information.
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-
 
 name: Import Terraform State
 on:
@@ -42,12 +41,10 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-run-tf-taint.yml
+++ b/workflow-templates/im-run-tf-taint.yml
@@ -1,10 +1,10 @@
-# Workflow Code: GratefulTermite_v2    DO NOT REMOVE
-# Purpose: 
+# Workflow Code: GratefulTermite_v3    DO NOT REMOVE
+# Purpose:
 #    Taints a specified terraform resource when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    -  Terraform (Optional Template)
 #
@@ -37,12 +37,10 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-run-unlock-tf-state.yml
+++ b/workflow-templates/im-run-unlock-tf-state.yml
@@ -1,10 +1,10 @@
-# Workflow Code: FrazzledFerret_v8    DO NOT REMOVE
-# Purpose: 
+# Workflow Code: FrazzledFerret_v9    DO NOT REMOVE
+# Purpose:
 #    Removes a lock from the terraform state when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    - Terraform (Core Template)
 #
@@ -37,12 +37,10 @@ env:
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
   # The following SSH_* secrets are org-level secrets
-  SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
   SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
   SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
   SSH_DEPLOY_KEY_INFO: |
     [
-      { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
       { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
       { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
     ]

--- a/workflow-templates/im-run-validate-deployed-terraform.yml
+++ b/workflow-templates/im-run-validate-deployed-terraform.yml
@@ -1,5 +1,5 @@
-# Workflow Code: ShinySQUIRREL_v10    DO NOT REMOVE
-# Purpose: 
+# Workflow Code: ShinySQUIRREL_v11    DO NOT REMOVE
+# Purpose:
 #    Validates that the deployed terraform matches what is supposed to be deployed
 #    when it runs at a scheduled time or when someone kicks it off manually.
 #
@@ -50,12 +50,10 @@ jobs:
       TF_WORKING_DIR: './${{ matrix.environment }}' # TODO: Verify this directory structure would be correct for your repository
       REPO_URL: https://github.com/${{ github.repository }}
       # The following SSH_* secrets are org-level secrets
-      SSH_KEY_CENTRAL_LOGGING: ${{ secrets.SSH_CENTRAL_LOGGING }}
       SSH_KEY_STORAGE_ACCOUNT: ${{ secrets.SSH_STORAGE_ACCOUNT }}
       SSH_KEY_NETWORK_INFO: ${{ secrets.SSH_NETWORK_INFO }}
       SSH_DEPLOY_KEY_INFO: |
         [
-          { "orgAndRepo": "im-platform/central-logging", "envName" : "SSH_KEY_CENTRAL_LOGGING" },
           { "orgAndRepo": "im-platform/storage-account-network-rules", "envName" : "SSH_KEY_STORAGE_ACCOUNT" },
           { "orgAndRepo": "im-platform/network-information", "envName" : "SSH_KEY_NETWORK_INFO" }
         ]


### PR DESCRIPTION
 Removing central logging ssh key from each of the workflows since it is now deprecated.