### PR TITLE
Simplified the build-nuget-package template

### DIFF
--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v19    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v20    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -37,7 +37,6 @@ on:
 env:
   READ_PKG_TOKEN: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret # TODO: this env can be removed if the project does not contain an .npmrc/nuget.config file that needs this value
   TIMEZONE: 'america/denver' # TODO: Verify timezone
-  REPO_URL: 'https://github.com/${{ github.repository }}'
 
 jobs:
   examine-triggers:
@@ -82,7 +81,7 @@ jobs:
           schema-file-path: 'SAM'
 
   build-test-publish:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, ubuntu-20.04] # TODO: decide whether to run on a self-hosted runner. It's only necessary if pushing the package to Artifactory.
     needs: [examine-triggers, validate-sam-yaml]
     if: needs.examine-triggers.outputs.CONTINUE_WORKFLOW == 'true'
 
@@ -103,7 +102,6 @@ jobs:
       NUGET_PROJ_DIR: '' # TODO: Add the directory containing the nuget package project like, ./src/MyNugetProj
       NUGET_PROJ_NAME: '' # TODO: Add the name of the csproj for the nuget package
       NUGET_TEST_PROJECT: '' # TODO: Add the filename including path of the test project for your nuget package like ./tests/nugetTest/nugetTest.csproj
-      ORGANIZATION: '' # TODO: Add the github organization of the repo lives in
       PKG_NAME: '' # TODO: If dual publishing to artifactory, add the name of the nuget package in Artifactory, otherwise delete
       # CSPROJ_NAME: '' # TODO: For older projects that must be built with nuget pack (instead of dotnet pack) add the name of your csproj file, otherwise delete
 
@@ -125,8 +123,27 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: dotnet build nuget project
-        run: dotnet build ${{ env.NUGET_PROJ_DIR }}/${{ env.NUGET_PROJ_NAME }} --configuration Release
+      - name: Calculate next version
+        id: version
+        uses: im-open/git-version-lite@v2.0.6
+        with:
+          calculate-prerelease-version: ${{ env.PRERELEASE }}
+          branch-name: ${{ github.head_ref }} # This is only populated when the trigger is pull_request, otherwise it is empty
+          tag-prefix: 'none' # TODO: verify your prefix, the new ci workflows add v automatically but nuget packages typically won't have a prefix
+
+      - name: dotnet build and pack nuget project
+        # dotnet pack also builds by default, so just go ahead and create the package.
+        # Set "PackageOutputPath" to place the resulting .nupkg file where the "Push to GH Packages" step can find it later.
+        # Set "Version" which, by default, becomes both the assembly and Package version.
+        # TODO: There are other methods for setting the version besides specifying it here.  You can update the value in the .csproj before building
+        #        and remove the -p:Version property below, or the version could be passed in from a workflow_dispatch input if desired.
+        # Set "RepositoryUrl" so the resulting nupkg is ready to be uploaded to GitHub packages and so the repo name and location doesn't need to be hard-coded in the .csproj.
+        run: dotnet pack ${{ env.NUGET_PROJ_DIR }}/${{ env.NUGET_PROJ_NAME }} --configuration Release -p:PackageOutputPath=${{ env.NUGET_PROJ_DIR }} -p:Version=${NEXT_VERSION:1} -p:RepositoryUrl=${{ github.repositoryUrl }}
+
+      # TODO: If this is an older project you may need to use the nuget command directly and add options as applicable.
+      # - name: Nuget Pack
+      #   working-directory: ${{ env.NUGET_PROJ_DIR }}
+      #   run: nuget pack ${{ env.CSPROJ_NAME }} -Build -Properties Configuration=Release;version="${{ steps.version.outputs.NEXT_VERSION }}"
 
       - name: dotnet build test project
         run: dotnet build ${{ env.NUGET_TEST_PROJECT }} --configuration Release
@@ -136,7 +153,7 @@ jobs:
       # TODO: Filters can be added to exclude certain tests: https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit
       - name: dotnet test with coverage
         continue-on-error: true
-        run: dotnet test ${{ env.NUGET_TEST_PROJECT }} --logger trx --no-restore --configuration Release /property:CollectCoverage=True /property:CoverletOutputFormat=opencover
+        run: dotnet test ${{ env.NUGET_TEST_PROJECT }} --logger trx --no-build --configuration Release /property:CollectCoverage=True /property:CoverletOutputFormat=opencover
 
       - name: create status check/comment for test results
         id: dotnet_test_check
@@ -192,26 +209,6 @@ jobs:
           echo "There were test or code coverage failures.  A release will not be created."
           exit 1
 
-      - name: Calculate next version
-        id: version
-        uses: im-open/git-version-lite@v2.0.6
-        with:
-          calculate-prerelease-version: ${{ env.PRERELEASE }}
-          branch-name: ${{ github.head_ref }} # This is only populated when the trigger is pull_request, otherwise it is empty
-          tag-prefix: 'none' # TODO: verify your prefix, the new ci workflows add v automatically but nuget packages typically won't have a prefix
-
-      # TODO: There are other methods for setting the version besides specifying it here.  You can update the value in the .csproj before building
-      #        and remove the -p:PackageVersion prop below, or the version could be passed in from a workflow_dispatch input if desired.
-      #        Determine if git-version-lite's version is appropriate to use for the package version.
-      - name: Dotnet Pack
-        working-directory: ${{ env.NUGET_PROJ_DIR }}
-        run: dotnet pack --no-build --configuration Release -p:PackageVersion=${{ steps.version.outputs.NEXT_VERSION }}
-
-      # TODO: If this is an older project you may need to use the nuget command directly and add options as applicable.
-      # - name: Nuget Pack
-      #   working-directory: ${{ env.NUGET_PROJ_DIR }}
-      #   run: nuget pack ${{ env.CSPROJ_NAME }} -Build -Properties Configuration=Release;version="${{ steps.version.outputs.NEXT_VERSION }}"
-
       # If this version already exists in GitHub Packages, this step will fail.
       - name: Push to GH Packages
         working-directory: ${{ env.NUGET_PROJ_DIR }}
@@ -220,7 +217,7 @@ jobs:
           nupkg=$(find . -type f -name "*.nupkg")
 
           # GITHUB_TOKEN is a special per-job token generated by GH for interacting with the repo
-          dotnet nuget push "$nupkg" --source "https://nuget.pkg.github.com/${{ env.ORGANIZATION }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
+          dotnet nuget push "$nupkg" --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
 
           # TODO: Remove the remaining items in this run step if you do not wish to publish to Artifactory
           isMergeToMain=${{ env.IS_MERGE_TO_MAIN }}
@@ -251,7 +248,7 @@ jobs:
         uses: im-open/delete-branch-package-versions@v1.0.2
         with:
           github-token: ${{ secrets.GH_PACKAGES_TOKEN }} # This is a special org-level secret that needs to be authorized for this repo
-          organization: '' # TODO: Add the organization this repo is in
+          organization: ${{ github.repository_owner }}
           branch-name: ${{ github.head_ref }}
           package-type: 'nuget'
           package-name: '' # TODO: Add the name of the package (the base name without any versions, like IdentityCient or Mktp.Logging)
@@ -300,12 +297,12 @@ jobs:
             let testPackageText = '';
             if (nextVersion && nextVersion.length > 0) {
               tagText =  isMergeToMain ?
-                `- [Tag - ${nextVersion}](${{ env.REPO_URL }}/releases/tag/${nextVersion})` :
+                `- [Tag - ${nextVersion}](${{ github.repositoryUrl }}/releases/tag/${nextVersion})` :
                 `- Next Version - ${nextVersion}`;
             }
 
             const commentBody = `
-            - [Workflow Run - ${{ steps.conclusion.outputs.workflow_conclusion }}](${{ env.REPO_URL }}/actions/runs/${{ github.run_id }})
+            - [Workflow Run - ${{ steps.conclusion.outputs.workflow_conclusion }}](${{ github.repositoryUrl }}/actions/runs/${{ github.run_id }})
             ${tagText}
               `;
             github.issues.createComment({


### PR DESCRIPTION
`REPO_URL` and `ORGANIZATION` can come directly from github context instead of being set by hand.

Moving the version determination earlier and packaging the NuGet at the same time as build to speed things up just a little and ensure the build properties, and especially the version numbers of the assembly and package align with each other.

Removing the redundant build triggered by the call to `dotnet test`