### PR TITLE
ARCH-1190 - Update any usages of `env.ENVIRONMENT` in `environment:`

### DIFF
--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmbitiousLizard_v25    DO NOT REMOVE
+# Workflow Code: AmbitiousLizard_v26    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified
@@ -123,7 +123,7 @@ jobs:
   stakeholder-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -134,7 +134,7 @@ jobs:
   attestor-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -177,7 +177,7 @@ jobs:
   deploy-code:
     needs: [set-vars, validate-tag-is-in-main-for-prod-deploys]
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v13    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v14    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -82,7 +82,7 @@ jobs:
   stakeholder-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
       - name: Approval Received
@@ -93,7 +93,7 @@ jobs:
   attestor-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -129,7 +129,7 @@ jobs:
   deploy-az-db:
     needs: [validate-tag-for-prod-deploys]
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
 

--- a/workflow-templates/im-deploy-az-swap-app-slots.yml
+++ b/workflow-templates/im-deploy-az-swap-app-slots.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritatedHyena_v9    DO NOT REMOVE
+# Workflow Code: IrritatedHyena_v10    DO NOT REMOVE
 # Purpose:
 #    Swaps deployment slots in a specified environment for an Azure App Service
 #    or Function outside of a deployment when someone kicks it off manually.
@@ -46,25 +46,17 @@ on:
 jobs:
   swap-slots:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment || github.event.client_payload.environment }}
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window
       PAGERDUTY_WINDOW_DESC: 'Deploying Code to ${{ env.ENVIRONMENT }} from GitHub Actions' # TODO: Verify this PD Maintenance Window Description
       TARGET_SLOT: 'Production' # TODO: Verify that this is correct.  This is the name azure uses by default.  If you are using a different slot for your main site, update it here
       SOURCE_SLOT: '' # TODO: Add the name of the source slot
       AZ_APP_TYPE: 'webapp' # TODO: If this workflow is for an azure function, change this value to functionapp
+      ENVIRONMENT: ${{ github.event.inputs.environment || github.event.client_payload.environment }}
+      OPEN_WINDOW: ${{ github.event.inputs.open-pagerduty-window || github.event.client_payload.open-pagerduty-window }}
 
     steps:
-      - run: |
-          eventName=${{ github.event_name }}
-          if [ "$eventName" == "workflow_dispatch" ]; then
-            echo "ENVIRONMENT=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
-            echo "OPEN_WINDOW=${{ github.event.inputs.open-pagerduty-window }}" >> $GITHUB_ENV
-          elif [ "$eventName" == "repository_dispatch" ]; then
-            echo "ENVIRONMENT=${{ github.event.client_payload.environment }}" >> $GITHUB_ENV
-            echo "OPEN_WINDOW=${{ github.event.client_payload.open-pagerduty-window }}" >> $GITHUB_ENV
-          fi
-
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}"
 
       # For more information and best practices on the usage and options available

--- a/workflow-templates/im-deploy-files-to-az-storage-account.yml
+++ b/workflow-templates/im-deploy-files-to-az-storage-account.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BubblyGreyhound_v13    DO NOT REMOVE
+# Workflow Code: BubblyGreyhound_v14    DO NOT REMOVE
 # Purpose:
 #    Checks out the repository and deploys a directory to the
 #    specified storage account when someone kicks it off manually.
@@ -47,7 +47,7 @@ jobs:
   deploy-to-azure:
     runs-on: [self-hosted, ubuntu-20.04]
 
-    environment: ${{ env.ENVIRONMENT }} # TODO: Verify the environment
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The branch/tag/sha is ${{ env.GITHUB_REF }}."

--- a/workflow-templates/im-deploy-multiple-items-at-once.yml
+++ b/workflow-templates/im-deploy-multiple-items-at-once.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MercifulLlama_v5    DO NOT REMOVE
+# Workflow Code: MercifulLlama_v6    DO NOT REMOVE
 # Purpose:
 #    This is only required when teams have separate deployable artifacts (db/mfe/api/etc.)
 #    but they need each item to be deployed together.
@@ -64,7 +64,7 @@ jobs:
   stakeholder-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -75,7 +75,7 @@ jobs:
   attestor-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v14    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v15    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -84,7 +84,7 @@ jobs:
   stakeholder-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
       - name: Approval Received
@@ -95,7 +95,7 @@ jobs:
   attestor-approval:
     needs: [verify-tag-exists]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -131,7 +131,7 @@ jobs:
   deploy-on-prem-db:
     needs: [validate-tag-for-prod-deploys]
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
 

--- a/workflow-templates/im-deploy-on-prem-website.yml
+++ b/workflow-templates/im-deploy-on-prem-website.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FuzzyDragon_v23    DO NOT REMOVE
+# Workflow Code: FuzzyDragon_v24    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified environments,
@@ -181,7 +181,7 @@ jobs:
   stakeholder-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - name: Approval Received
         run: |
@@ -193,7 +193,7 @@ jobs:
   attestor-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -236,7 +236,7 @@ jobs:
   deploy-site:
     needs: [set-vars, validate-tag-is-in-main-for-prod-deploys]
     runs-on: [self-hosted, windows-2019]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v24    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v25    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform at a specified tag to a specified
 #    environment when someone kicks off the build manually.
@@ -104,7 +104,7 @@ jobs:
   stakeholder-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The branch/tag/sha is ${{ env.GITHUB_REF }}."
       - name: Approval Received
@@ -140,7 +140,7 @@ jobs:
   tf-plan:
     needs: [set-vars, validate-tag-is-in-main-for-prod-deploys]
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
     env:
       PAGERDUTY_WINDOW_DESC: 'Deploying Infrastructure to the ${{ env.ENVIRONMENT }} environment from GitHub Actions' # TODO: Verify this description
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window
@@ -247,7 +247,7 @@ jobs:
   tf-apply:
     needs: [set-vars, tf-plan, tf-plan-manual-approval]
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:
       run:

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MaterialVolcano_v17    DO NOT REMOVE
+# Workflow Code: MaterialVolcano_v18    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -156,7 +156,7 @@ jobs:
   stakeholder-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Stakeholder Approval'
+    environment: '${{ github.event.inputs.environment }} Stakeholder Approval' # Use inputs context because env context is not available to environment:
     steps:
       - name: Approval Received
         run: |
@@ -168,7 +168,7 @@ jobs:
   attestor-approval:
     needs: [set-vars]
     runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
-    environment: '${{ env.ENVIRONMENT }} Attestor Approval'
+    environment: '${{ github.event.inputs.environment }} Attestor Approval' # Use inputs context because env context is not available to environment:
     steps:
       - run: |
           echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."
@@ -211,7 +211,7 @@ jobs:
   deploy-service:
     needs: [set-vars, stakeholder-approval, validate-tag-for-prod-deploys]
     runs-on: [self-hosted, windows-2019]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window

--- a/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
+++ b/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
@@ -1,11 +1,11 @@
-# Workflow Code: CockySquirrel_v7    DO NOT REMOVE
-# Purpose: 
+# Workflow Code: CockySquirrel_v8    DO NOT REMOVE
+# Purpose:
 #    Adds or updates an azure KeyVault secret in the specified
 #    environment when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow can be duplicated for each keyvault this repository contains
-#    
+#
 # Projects to use this Template with:
 #    - Terraform (Optional Template)
 #    - Azure App Service or Function (Optional Template)
@@ -37,14 +37,11 @@ on:
           - uat
           - prod
 
-env:
-  ENVIRONMENT: ${{ github.event.inputs.environment }}
-
 jobs:
   set-secret:
     runs-on: [self-hosted, ubuntu-20.04]
 
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }}
 
     steps:
       - name: Mask the secret value
@@ -54,14 +51,14 @@ jobs:
             core.info(`Masking the value for ${context.payload.inputs.secret_name} so it is not exposed.`);
             core.setSecret(context.payload.inputs.secret_value);
 
-      - run: echo "The current environment is ${{ env.ENVIRONMENT }}"
+      - run: echo "The current environment is ${{ github.event.inputs.environment }}"
 
       # For more information and best practices on the usage and options available
       # for this action go to: https://github.com/im-open/set-environment-variables-by-scope#usage-instructions
       - name: Set Variables
         uses: im-open/set-environment-variables-by-scope@v1.0.4
         with:
-          scope: ${{ env.ENVIRONMENT }}
+          scope: ${{ github.event.inputs.environment }}
         env:
           # TODO: For the following keyvault name inputs, fill in the value if you have the environment and delete the environment if it does not exist
           KEYVAULT_NAME@dev: ''

--- a/workflow-templates/im-run-annotate-app-insights.yml
+++ b/workflow-templates/im-run-annotate-app-insights.yml
@@ -1,15 +1,15 @@
-# Workflow Code: EmpatheticDolphin_v9    DO NOT REMOVE
-# Purpose: 
-#    Creates an ad hoc app insights annotation for a specified 
+# Workflow Code: EmpatheticDolphin_v10    DO NOT REMOVE
+# Purpose:
+#    Creates an ad hoc app insights annotation for a specified
 #    environment when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository assuming
 #      there is only one app insights instance set up per env
-#    
+#
 # Projects to use this Template with:
 #    - Azure App Service or Function (Optional Template)
-#    - Azure SQL Database            (Optional Template) 
+#    - Azure SQL Database            (Optional Template)
 #    - Terraform                     (Optional Template)
 #
 # TODO: Prerequisites:
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: The environment the service is in 
+        description: The environment the service is in
         required: true
         default: prod
         type: choice
@@ -50,9 +50,9 @@ env:
 jobs:
   create-annotation:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }}
     steps:
-      - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The event is ${{ github.event.inputs.eventName }}"
+      - run: echo "The current environment is ${{ github.event.inputs.environment }}.  The event is ${{ github.event.inputs.eventName }}"
 
       # For more information and best practices on the usage and options available
       # for this action go to: https://github.com/im-open/set-environment-variables-by-scope#usage-instructions
@@ -60,7 +60,7 @@ jobs:
         id: set-variables
         uses: im-open/set-environment-variables-by-scope@v1.0.4
         with:
-          scope: ${{ env.ENVIRONMENT }}
+          scope: ${{ github.event.inputs.environment }}
         env:
           # This variable is used to upload and download blobs from blob storage
           RESOURCE_GROUP@dev: ''

--- a/workflow-templates/im-run-delete-azure-blob.yml
+++ b/workflow-templates/im-run-delete-azure-blob.yml
@@ -1,10 +1,10 @@
-# Workflow Code: ScornfulFlamingo_v2   DO NOT REMOVE
-# Purpose: 
+# Workflow Code: ScornfulFlamingo_v3   DO NOT REMOVE
+# Purpose:
 #    Deletes a blob from a specified Azure Storage Account when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should only be used once per repository
-#    
+#
 # Projects to use this Template with:
 #    - Storage Account Deployments (Core Template)
 #
@@ -40,17 +40,14 @@ on:
           - uat
           - prod
 
-env:
-  ENVIRONMENT: ${{ github.event.inputs.ENVIRONMENT }}
-
 jobs:
   delete-blob:
     runs-on: [self-hosted, ubuntu-20.04]
 
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }}
 
     steps:
-      - run: echo "The current environment is ${{ env.ENVIRONMENT }}."
+      - run: echo "The current environment is ${{ github.event.inputs.environment }}."
 
       - name: AZ Login
         id: login

--- a/workflow-templates/im-run-flyway-repair.yml
+++ b/workflow-templates/im-run-flyway-repair.yml
@@ -1,11 +1,11 @@
-# Workflow Code: SpiritedGnat_v7    DO NOT REMOVE
-# Purpose: 
-#    Runs a flyway repair command against an Azure SQL or 
+# Workflow Code: SpiritedGnat_v8    DO NOT REMOVE
+# Purpose:
+#    Runs a flyway repair command against an Azure SQL or
 #    On-Prem Database when someone kicks it off manually.
 #
 # Frequency:
 #    - This workflow can be duplicated once per database in the repository.
-#    
+#
 # Projects to use this Template with:
 #    - Azure Sql Database (Optional Template)
 #    - On-Prem Database   (Optional Template)
@@ -44,7 +44,7 @@ env:
 jobs:
   repair-database-migrations:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}."
 

--- a/workflow-templates/im-run-start-stop-restart-azure-app.yml
+++ b/workflow-templates/im-run-start-stop-restart-azure-app.yml
@@ -1,11 +1,11 @@
-# Workflow Code: NeedyPig_v8    DO NOT REMOVE
-# Purpose: 
-#    Performs a start, stop or restart on an app service in the 
+# Workflow Code: NeedyPig_v9    DO NOT REMOVE
+# Purpose:
+#    Performs a start, stop or restart on an app service in the
 #    specified environment when someone kicks it off manually.
-#    
+#
 # Frequency:
 #    - This workflow should be duplicated once per app service/function in the repo.
-#    
+#
 # Projects to use this Template with:
 #    - Azure App Service or Function (Optional Template)
 #
@@ -46,11 +46,11 @@ env:
 jobs:
   start-stop-restart:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:
       AZ_APP_TYPE: 'webapp' # TODO: If this workflow is for an azure function change the value to 'functionapp'
-      
+
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}"
 

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v4    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v5    DO NOT REMOVE
 # Purpose:
 #    Destroys all the remote objects for a terraform configuration when someone kicks it off manually.
 #
@@ -54,7 +54,7 @@ env:
 jobs:
   tf-destroy:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:
       run:

--- a/workflow-templates/im-run-tf-import.yml
+++ b/workflow-templates/im-run-tf-import.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DrearyBuck_v7    DO NOT REMOVE
+# Workflow Code: DrearyBuck_v8    DO NOT REMOVE
 
 # Purpose:
 #    Imports a specified resource into the terraform state when someone kicks it off manually.
@@ -17,10 +17,10 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: The environment the import should be done in. 
+        description: The environment the import should be done in.
         required: true
         type: choice
-        options:  # TODO: Update for the environments that are available
+        options: # TODO: Update for the environments that are available
           - dev
           - qa
           - stage
@@ -60,7 +60,7 @@ env:
 jobs:
   tf-import-state:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:
       run:

--- a/workflow-templates/im-run-tf-taint.yml
+++ b/workflow-templates/im-run-tf-taint.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GratefulTermite_v4    DO NOT REMOVE
+# Workflow Code: GratefulTermite_v5    DO NOT REMOVE
 # Purpose:
 #    Taints a specified terraform resource when someone kicks it off manually.
 #
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: The environment the taint should be done in. 
+        description: The environment the taint should be done in.
         required: true
         type: choice
         options: # TODO: Update for the environments that are available
@@ -56,7 +56,7 @@ env:
 jobs:
   tf-taint-resource:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:
       run:

--- a/workflow-templates/im-run-unlock-tf-state.yml
+++ b/workflow-templates/im-run-unlock-tf-state.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FrazzledFerret_v10    DO NOT REMOVE
+# Workflow Code: FrazzledFerret_v11    DO NOT REMOVE
 # Purpose:
 #    Removes a lock from the terraform state when someone kicks it off manually.
 #
@@ -56,7 +56,7 @@ env:
 jobs:
   tf-unlock-state:
     runs-on: [self-hosted, ubuntu-20.04]
-    environment: ${{ env.ENVIRONMENT }}
+    environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:
       run:
@@ -69,7 +69,7 @@ jobs:
         with:
           ref: ${{ env.GITHUB_REF }}
 
-      - run: echo "The current environment is ${{ env.ENVIRONMENT }}.   The branch/tag/sha is ${{ env.GITHUB_REF }}."
+      - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The branch/tag/sha is ${{ env.GITHUB_REF }}."
 
       # Allows pulling modules from the repo instead of artifactory
       - name: Setup SSH Keys and known_hosts


### PR DESCRIPTION
Update any usages of `env.ENVIRONMENT` to `github.event.inputs.environment` when used to populate `environment:`.  

The env context is not available to jobs.id.environment. You can only use things from the github, needs, strategy, matrix or inputs contexts in that field. Which makes sense because before we would have been using an output from the set-vars job (the needs context). Using the env.ENVIRONMENT variable in other places where just fine where it had access to the env context so there was no naming clash which is initially what I thought might be happening.