### PR TITLE
Updating im-test-sam-yaml to use self-hosted runners.

### DIFF
--- a/workflow-templates/im-test-sam-yaml.yml
+++ b/workflow-templates/im-test-sam-yaml.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DigitalWerewolf_v2    DO NOT REMOVE
+# Workflow Code: DigitalWerewolf_v3    DO NOT REMOVE
 # Purpose:
 #    Runs the SAM YAML Validation action and exports the
 #    output JSON into the Stewardship Mapping document repository

--- a/workflow-templates/im-test-sam-yaml.yml
+++ b/workflow-templates/im-test-sam-yaml.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   sam-yaml:
     name: Validate and Export SAM YAML
-    runs-on: [ubuntu-latest]
+    runs-on: [self-hosted, ubuntu-20.04]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Because the stewardship export is on by default, this must run on a self-hosted runner, otherwise the json upload will come from the public internet and will be blocked by Cosmos IP restrictions.