### PR TITLE
Update the run flyway command and add new instructions.

### DIFF
--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
+      # TODO: If your database uses Azure Active Directory Authentication then this step can be removed
       - name: AZ Login
         uses: azure/login@v1
         with:
@@ -173,6 +174,7 @@ jobs:
           AZURE_KEY_VAULT@prod: ''
 
       # Get the Azure SQL Creds from Key Vault
+      # TODO: If your database uses Azure Active Directory Authentication then this step can be removed
       - name: Get Azure SQL Credentials
         run: |
           sqlUser=$(az keyvault secret show --vault-name "${{ env.AZURE_KEY_VAULT }}" --name "sqluser" --query value)
@@ -184,8 +186,11 @@ jobs:
           echo "SQL_USER=$sqlUser" >> $GITHUB_ENV
           echo "SQL_PASSWORD=$sqlPassword" >> $GITHUB_ENV
 
+      # TODO: If your database uses Azure Active Directory Authentication then you can login with a Service Principal
+      #       instead of using the username and password of an account stored in Key Vault.
+      #       See https://github.com/im-open/run-flyway-command for details.
       - name: Deploy migrations
-        uses: im-open/run-flyway-command@v1.2.1
+        uses: im-open/run-flyway-command@v1.4.0
         with:
           db-server-name: '${{ steps.db-vars.outputs.DB_SERVER_NAME }}'
           db-server-port: '${{ env.DB_SERVER_PORT }}'

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -195,7 +195,7 @@ jobs:
             database/static-creds/<role-name> password | SQL_AUTH_PASSWORD
 
       - name: Deploy migrations
-        uses: im-open/run-flyway-command@v1.2.1
+        uses: im-open/run-flyway-command@v1.4.0
         with:
           db-server-name: '${{ steps.environment-specific-vars.outputs.DB_SERVER_NAME }}'
           db-server-port: '${{ env.DB_SERVER_PORT }}'

--- a/workflow-templates/im-run-flyway-repair.yml
+++ b/workflow-templates/im-run-flyway-repair.yml
@@ -59,6 +59,8 @@ jobs:
         with:
           version: 7.9.2
 
+      # TODO: Remove this step if this workflow is run against an on-prem database
+      #       or if your database uses Azure Active Directory Authentication
       - name: AZ Login
         id: login
         uses: azure/login@v1
@@ -92,6 +94,7 @@ jobs:
           AZURE_KEY_VAULT@prod: ''
 
       # TODO: Remove this step if this workflow is run against an on-prem database
+      #       or if your database uses Azure Active Directory Authentication
       # Get the Azure SQL Creds from Key Vault
       - name: Get Azure SQL Credentials
         run: |
@@ -129,8 +132,11 @@ jobs:
       #       database/static-creds/<role-name> username | SQL_USERNAME ;
       #       database/static-creds/<role-name> password | SQL_PASSWORD
 
+      # TODO: If your database uses Azure Active Directory Authentication then you can login with a Service Principal
+      #       instead of using the username and password of an account stored in Key Vault.
+      #       See https://github.com/im-open/run-flyway-command for details.
       - name: Flyway repair
-        uses: im-open/run-flyway-command@v1.2.1
+        uses: im-open/run-flyway-command@v1.4.0
         with:
           flyway-command: 'repair'
           db-server-name: ${{ steps.db-vars.outputs.DB_SERVER_NAME }}


### PR DESCRIPTION
The run-flyway-command action now allows for using an azure service principal or managed service identity to authenticate with the database. We're updating the action's version and adding some instructions around that.