### PR TITLE
Add reusable workflows

### DIFF
--- a/.github/workflows/reusable-examine-triggers.yml
+++ b/.github/workflows/reusable-examine-triggers.yml
@@ -2,15 +2,11 @@
 
 # Example Usage in a repo's workflow:
 # jobs:
-#  validate-tag-is-in-main-for-prod-deploys:
+#  examine-triggers:
 #    needs: [set-vars, stakeholder-approval, attestor-approval]
-#    uses: im-enrollment/resolve-tag-action/.github/workflows/reusable-validate-production-tag.yml@vlatest
-#    secrets: inherit
-#    with:
-#      tag: v1.2.3
-#      environment: prod
+#    uses: im-enrollment/.github/.github/workflows/reusable-examine-triggers.yml@v1
 
-name: Reusable - Validate Tag is ready for Production Deploys
+name: Reusable - Examine workflow triggers
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/reusable-examine-triggers.yml
+++ b/.github/workflows/reusable-examine-triggers.yml
@@ -1,0 +1,86 @@
+# Implements https://github.com/im-enrollment/.github/blob/1b9ed2b04a06d0b25b390e447d1554271d4c5ee5/workflow-templates/im-build-dotnet-ci.yml#L52
+
+# Example Usage in a repo's workflow:
+# jobs:
+#  validate-tag-is-in-main-for-prod-deploys:
+#    needs: [set-vars, stakeholder-approval, attestor-approval]
+#    uses: im-enrollment/resolve-tag-action/.github/workflows/reusable-validate-production-tag.yml@vlatest
+#    secrets: inherit
+#    with:
+#      tag: v1.2.3
+#      environment: prod
+
+name: Reusable - Validate Tag is ready for Production Deploys
+on:
+  workflow_call:
+    inputs:
+      base-branch:
+        description: Default branch of which contains the tag
+        required: false
+        type: string
+        default: main
+        
+      runs-on:
+        description: Verify associated release is not draft or prerelease
+        required: false
+        type: string
+        default: ubuntu-latest
+        
+    outputs:
+      CONTINUE_WORKFLOW:
+        description: Indicate if the workflow may continue
+        value: ${{ jobs.examine.outputs.CONTINUE_WORKFLOW }}
+        
+      CREATE_RELEASE:
+        description: Indicate if a release may be created
+        value: ${{ jobs.examine.outputs.CREATE_RELEASE }}
+        
+      IS_PRERELEASE:
+        description: Indicate if a prerelease should be created
+        value: ${{ jobs.examine.outputs.IS_PRERELEASE }}
+        
+      REF_TO_BUILD_AND_TAG:
+        description: The reference to build and tag
+        value: ${{ jobs.examine.outputs.REF_TO_BUILD_AND_TAG }}
+      
+jobs:
+  examine:
+    runs-on: ${{ inputs.runs-on }} 
+    
+    outputs:
+      CONTINUE_WORKFLOW: ${{ env.CONTINUE_WORKFLOW }}
+      CREATE_RELEASE: ${{ env.CREATE_RELEASE }}
+      IS_PRERELEASE: ${{ env.IS_PRERELEASE }}
+      REF_TO_BUILD_AND_TAG: ${{ env.REF_TO_BUILD_AND_TAG }}
+
+    steps:
+      - name: Set default env variables
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const targetRef = '${{ github.base_ref }}';
+            const sourceRef = '${{ github.head_ref }}';
+            const mergeRef = '${{ github.ref }}';
+
+            const prIsDraft = '${{ github.event.pull_request.draft }}' === 'true';
+            const prClosed = '${{ github.event.action }}' === 'closed';
+            const prMerged = prClosed && '${{ github.event.pull_request.merged }}' === 'true';
+            const prMergedToMain = prMerged && targetRef === '${{ inputs.base-branch }}';
+            const isPreRelease = !prMergedToMain;
+
+            // For a detailed explanation of why we use different refs for different scenarios 
+            // see https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
+            const refToBuildAndTag = prMergedToMain ? mergeRef : sourceRef;
+
+            const continueWorkflow = prClosed && !prMerged ? false : true;
+            const doTagRelease = continueWorkflow && !prIsDraft ? true :  false;
+            
+            object.entries({
+              CONTINUE_WORKFLOW: continueWorkflow,
+              CREATE_RELEASE: doTagRelease,
+              IS_PRERELEASE: isPreRelease,
+              REF_TO_BUILD_AND_TAG: refToBuildAndTag
+            }).forEach(pair => {
+              core.exportVariable(...pair);
+              console.info(...pair);
+            });

--- a/.github/workflows/reusable-examine-triggers.yml
+++ b/.github/workflows/reusable-examine-triggers.yml
@@ -10,7 +10,7 @@ name: Reusable - Examine workflow triggers
 on:
   workflow_call:
     inputs:
-      base-branch:
+      default-branch:
         description: Default branch of which contains the tag
         required: false
         type: string
@@ -61,7 +61,7 @@ jobs:
             const prIsDraft = '${{ github.event.pull_request.draft }}' === 'true';
             const prClosed = '${{ github.event.action }}' === 'closed';
             const prMerged = prClosed && '${{ github.event.pull_request.merged }}' === 'true';
-            const prMergedToMain = prMerged && targetRef === '${{ inputs.base-branch }}';
+            const prMergedToMain = prMerged && targetRef === '${{ inputs.default-branch }}';
             const isPreRelease = !prMergedToMain;
 
             // For a detailed explanation of why we use different refs for different scenarios 

--- a/.github/workflows/reusable-examine-triggers.yml
+++ b/.github/workflows/reusable-examine-triggers.yml
@@ -41,7 +41,7 @@ on:
       
 jobs:
   examine:
-    runs-on: ${{ inputs.runs-on }} 
+    runs-on: ${{ inputs.runs-on }}
     
     outputs:
       CONTINUE_WORKFLOW: ${{ env.CONTINUE_WORKFLOW }}
@@ -71,7 +71,7 @@ jobs:
             const continueWorkflow = prClosed && !prMerged ? false : true;
             const doTagRelease = continueWorkflow && !prIsDraft ? true :  false;
             
-            object.entries({
+            Object.entries({
               CONTINUE_WORKFLOW: continueWorkflow,
               CREATE_RELEASE: doTagRelease,
               IS_PRERELEASE: isPreRelease,
@@ -80,3 +80,4 @@ jobs:
               core.exportVariable(...pair);
               console.info(...pair);
             });
+

--- a/.github/workflows/reusable-validate-tag.yml
+++ b/.github/workflows/reusable-validate-tag.yml
@@ -1,50 +1,59 @@
+# Implements https://github.com/im-enrollment/.github/blob/1b9ed2b04a06d0b25b390e447d1554271d4c5ee5/workflow-templates/im-deploy-az-app-manually.yml#L207
+
 # Example Usage in a repo's workflow:
 # jobs:
 #  validate-tag-is-in-main-for-prod-deploys:
 #    needs: [set-vars, stakeholder-approval, attestor-approval]
-#    uses: im-open/is-release-produciton-ready/.github/workflows/reusable-validate-tag.yml@v1
+#    uses: im-enrollment/resolve-tag-action/.github/workflows/reusable-validate-production-tag.yml@vlatest
 #    secrets: inherit
 #    with:
 #      tag: v1.2.3
-    
+#      environment: prod
+
 name: Reusable - Validate Tag is ready for Production Deploys
 on:
   workflow_call:
     inputs:
       environment:
         description: Environment running against
-        type: string
         required: true
+        type: string
 
       tag:
         description: The tag that should be checked
         required: true
         type: string
-        
-      production-environmment:
+      
+      production-environment:
         description: Name of the production environment to check against
-        required: true
+        required: false
         type: string
         default: prod
       
       base-branch:
         description: Default branch of which contains the tag
-        required: true
+        required: false
         type: string
         default: main
-        
-      verify-release:
+      
+      verify-release-production-ready:
         description: Verify associated release is not draft or prerelease
-        required: true
+        required: false
         type: boolean
         default: true
-  
+        
+      runs-on:
+        description: Verify associated release is not draft or prerelease
+        required: false
+        type: string
+        default: ubuntu-latest 
+
 jobs:
   validate-tag-is-in-base-branch:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }} 
 
     env:
-      IS_PROD: ${{ inputs.environment } == ${{ inputs.production-environment }}
+      IS_PROD: ${{ inputs.environment == inputs.production-environment }}
 
     steps:
       - run: echo "The current environment is ${{ inputs.environment }}.  The Tag is ${{ inputs.tag }}."
@@ -55,17 +64,17 @@ jobs:
         if: env.IS_PROD == 'true'
         uses: actions/checkout@v3
         with:
-          ref: ${{ input.base-branch }}
+          ref: ${{ inputs.base-branch }}
           fetch-depth: 0
 
       - uses: im-open/is-tag-reachable-from-default-branch@v1
         if: env.IS_PROD == 'true'
         with:
-          tag: ${{ inputs.-tag }}
+          tag: ${{ inputs.tag }}
 
       - uses: im-open/is-release-production-ready@v1
-        if: env.IS_PROD == 'true' && input.verify-release == true
+        if: env.IS_PROD == 'true' && inputs.verify-release-production-ready == true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ inputs.release-tag }}
+          release-tag: ${{ inputs.tag }}
           fail-for-prerelease: true # This only runs for prod environments, so if the release is not production ready it should fail

--- a/.github/workflows/reusable-validate-tag.yml
+++ b/.github/workflows/reusable-validate-tag.yml
@@ -1,0 +1,71 @@
+# Example Usage in a repo's workflow:
+# jobs:
+#  validate-tag-is-in-main-for-prod-deploys:
+#    needs: [set-vars, stakeholder-approval, attestor-approval]
+#    uses: im-open/is-release-produciton-ready/.github/workflows/reusable-validate-tag.yml@v1
+#    secrets: inherit
+#    with:
+#      tag: v1.2.3
+    
+name: Reusable - Validate Tag is ready for Production Deploys
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: Environment running against
+        type: string
+        required: true
+
+      tag:
+        description: The tag that should be checked
+        required: true
+        type: string
+        
+      production-environmment:
+        description: Name of the production environment to check against
+        required: true
+        type: string
+        default: prod
+      
+      base-branch:
+        description: Default branch of which contains the tag
+        required: true
+        type: string
+        default: main
+        
+      verify-release:
+        description: Verify associated release is not draft or prerelease
+        required: true
+        type: boolean
+        default: true
+  
+jobs:
+  validate-tag-is-in-base-branch:
+    runs-on: ubuntu-latest
+
+    env:
+      IS_PROD: ${{ inputs.environment } == ${{ inputs.production-environment }}
+
+    steps:
+      - run: echo "The current environment is ${{ inputs.environment }}.  The Tag is ${{ inputs.tag }}."
+
+      # In this job, always checkout the default branch (not the tag that was provided as an input).  Also use
+      # fetch-depth: 0 to retrieve the history and tags so we can check if a tag is reachable from the default branch.
+      - name: Checkout Repository
+        if: env.IS_PROD == 'true'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ input.base-branch }}
+          fetch-depth: 0
+
+      - uses: im-open/is-tag-reachable-from-default-branch@v1
+        if: env.IS_PROD == 'true'
+        with:
+          tag: ${{ inputs.-tag }}
+
+      - uses: im-open/is-release-production-ready@v1
+        if: env.IS_PROD == 'true' && input.verify-release == true
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-tag: ${{ inputs.release-tag }}
+          fail-for-prerelease: true # This only runs for prod environments, so if the release is not production ready it should fail

--- a/.github/workflows/reusable-validate-tag.yml
+++ b/.github/workflows/reusable-validate-tag.yml
@@ -4,7 +4,7 @@
 # jobs:
 #  validate-tag-is-in-main-for-prod-deploys:
 #    needs: [set-vars, stakeholder-approval, attestor-approval]
-#    uses: im-enrollment/resolve-tag-action/.github/workflows/reusable-validate-production-tag.yml@vlatest
+#    uses: im-practices/.github/.github/workflows/reusable-validate-production-tag.yml@v1
 #    secrets: inherit
 #    with:
 #      tag: v1.2.3

--- a/.github/workflows/reusable-validate-tag.yml
+++ b/.github/workflows/reusable-validate-tag.yml
@@ -30,7 +30,7 @@ on:
         type: string
         default: prod
       
-      base-branch:
+      default-branch:
         description: Default branch of which contains the tag
         required: false
         type: string
@@ -49,7 +49,7 @@ on:
         default: ubuntu-latest 
 
 jobs:
-  validate-tag-is-in-base-branch:
+  validate-tag:
     runs-on: ${{ inputs.runs-on }} 
 
     env:
@@ -64,7 +64,7 @@ jobs:
         if: env.IS_PROD == 'true'
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.base-branch }}
+          ref: ${{ inputs.default-branch }}
           fetch-depth: 0
 
       - uses: im-open/is-tag-reachable-from-default-branch@v1


### PR DESCRIPTION
Reusable workflow that can be used as a job in various team workflows.

Note that it is a requirement that they reside within the `.github/workflows` directory.

Note one problem with placing them in `.github` repo is they will need to include tagged versions so they can be referenced by other repos.

Another example is having these reusable workflows live more closely to what they are using.
https://github.com/im-open/is-release-production-ready/pull/8