### PR TITLE
ARCH-1853 - Switching to im-linux runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # .github
+
 Community Health Files for the `im-practices` organization.
 
 Each repository within this organization will inherit these default files unless the repository has defined their own.
 
 ## Workflow Templates
+
 The templates defined in this repository have been customized for our build processes and standards.  By including them in this repository, users can [add a workflow] to their repo by clicking a button.
 
 The templates defined in this repository are also the source of truth for the `im-` templates in each of the Enterprise Org `.github` repos.  When a merge to main happens, the template files in this repo will be copied to the other `.github` repositories in the Enterprise.  If changes have been made to any of the `im-` template files in those organizations' `.github` repos they will be overwritten by these changes.
@@ -17,12 +19,14 @@ Templates that are specific to an organization should be added directly to that 
 For detailed info around creating or modifying the templates see [Sharing workflows with your organization].
 
 The templates in this repository fall into one of the following categories:
+
 - Build
 - Deploy
 - Test
 - Run
- 
+
 ### Template Standards
+
 - For new `.svg` files ensure:
   - [ ] The file contains the `im_` prefix
 - For new `properties.json` files ensure:
@@ -50,25 +54,23 @@ The templates in this repository fall into one of the following categories:
   - [ ] Clearly state the format if something specific is required
   - [ ] If you want to use the github hosted runners use the `runs-on: ubuntu-latest` tag
   - [ ] If the workflow takes in the environment as a parameter, use the `type: choice` pattern that is implemented in other workflows like [im-deploy-tf-manual-apply.yml]
-  - For consistency, 
+  - For consistency:
     - [ ] Ensure there are spaces between the brackets and the expression when using expression syntax
       - Expected: ${{ secrets.thing }}
-      - Not expected: ${{secrets.mything}}
-    - [ ] If only one label is included in the `runs-on` property, do not include brackets
-      - Expected: `runs-on: ubuntu-latest`
-      - Not Expected: `runs-on: [ubuntu-latest]`
+      - Not expected: ${{secrets.thing}}
     - [ ] Outside of script blocks, use single `'` instead of double `"`
     - [ ] For any secrets, document whether it is an org, repo or environment level secret
-      
+
 ## start-project Integration
+
 This repository contains two files that enable integration with `start-project`:
+
 - [package.json]
   - This allows the repository to be restored via npm
 - [start-project-template-inventory.json]
   - This file tells `start-project` which workflow templates should be added to different project types
 
 When `start-project` runs, it restores this repository and examines the inventory file to determine which Workflows should be included.  The generator should include the latest version of the Workflow.
-
 
 [add a workflow]: https://docs.github.com/en/actions/guides/setting-up-continuous-integration-using-workflow-templates
 [Sharing workflows with your organization]: https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization

--- a/workflow-templates/im-build-db-ci.yml
+++ b/workflow-templates/im-build-db-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GiddyBuzzard_v13    DO NOT REMOVE
+# Workflow Code: GiddyBuzzard_v14    DO NOT REMOVE
 # Purpose:
 #    The main purpose of this workflow is to verify that the database can be created, all of the migration scripts can be run, and any tests that exist pass.
 #    In addition to that, however, there are three other things this workflow template is set up to do.
@@ -129,9 +129,20 @@ jobs:
           path-to-lint-config: ./.tsqllintrc # TODO: Update this with the path to your project's .tsllintrc file
 
   build-database:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [set-vars, lint-migration-files] # TODO: Remove any jobs you deleted above
     if: ${{ needs.set-vars.outputs.should-skip-remaining-workflow-jobs == 'false' }} # TODO: Remove this if there is no snapshot commit that should cause this step to be skipped.
+    
+    env:
+      SQL_SERVER_PASSWORD: 'StrongPassword!1'
+      
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        ports:
+          - 1433:1433
+        options: -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=StrongPassword!1"
+    
     steps:
       - uses: actions/checkout@v3
 
@@ -158,7 +169,7 @@ jobs:
           seed-data-files-path: '' # TODO: Add the path to the directory with your seed data files
           use-integrated-security: false
           db-username: 'sa' # The default system administrator account that comes with SQL Server. This is the only account set up in our self hosted Action Runners' SQL Server instances.
-          db-password: ${{ secrets.ACTIONS_RUNNER_MSSQL_SA_PWD }} # This is an org level secret. It is the password for the sa account.
+          db-password: ${{ env.SQL_SERVER_PASSWORD }}
 
 
       #########################################################################################################################

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v41    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v43    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -62,7 +62,7 @@ jobs:
 
   # TODO:  Remove this job and references to this job if the project does not use npm
   npm-cache:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
 
@@ -97,7 +97,7 @@ jobs:
 
       # This action creates a post-job step that will upload the node_modules dir to the cache if the job
       # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the node_modules
-      # folder if the package-lock.json hasn't changed and it uses a ubuntu-20.04 runner to restore the cache from.
+      # folder if the package-lock.json hasn't changed and it uses a im-linux runner to restore the cache from.
       - name: Setup caching for node_modules directory
         if: steps.has-cache.outputs.cache-hit == 'false'
         uses: actions/cache@v3
@@ -122,7 +122,7 @@ jobs:
         if: steps.has-cache.outputs.cache-hit == 'false'
 
   nuget-cache:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
 
@@ -158,7 +158,7 @@ jobs:
 
       # This action creates a post-job step that will upload the ./.nuget/packages dir to the cache if the job
       # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the ./.nuget/packages
-      # folder if the csproj files haven't changed and it uses a ubuntu-20.04 runner to restore the cache from.
+      # folder if the csproj files haven't changed and it uses a im-linux runner to restore the cache from.
       - name: Setup caching for nuget packages
         if: steps.has-cache.outputs.cache-hit == 'false'
         uses: actions/cache@v3
@@ -186,7 +186,7 @@ jobs:
         if: steps.has-cache.outputs.cache-hit == 'false'
 
   dotnet-test:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow, nuget-cache]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
 
@@ -210,6 +210,15 @@ jobs:
       INSTALL_MOCK_DB_OBJ: '' # TODO: [true|false] Indicates whether you want mock objects installed on the db.  Delete if not using.
       MOCK_DB_OBJ_URL: '' # TODO: The url to the nuget feed that contains your mock db obs.  Delete if not using mock db objects.
       DROP_DB_AFTER_STEP: '' # TODO: [true|false] Indicates whether the db should be dropped after the build step
+      SQL_SERVER_PASSWORD: 'StrongPassword!1'
+      
+    # TODO:  Remove this services block if you do not setup a database to run tests against during ci
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        ports:
+          - 1433:1433
+        options: -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=StrongPassword!1"
 
     steps:
       - name: Checkout Repository
@@ -249,7 +258,16 @@ jobs:
           seed-data-files-path: '' # TODO: Add the path to the directory with your seed data files
           use-integrated-security: false
           db-username: 'sa' # The default system administrator account that comes with SQL Server. This is the only account set up in our self hosted Action Runners' SQL Server instances.
-          db-password: ${{ secrets.ACTIONS_RUNNER_MSSQL_SA_PWD }} # This is an org level secret. It is the password for the sa account.
+          db-password: ${{ env.SQL_SERVER_PASSWORD }} # This is an org level secret. It is the password for the sa account.
+
+      # TODO:  If you are setting up a sql database, you may need to update connection strings
+      #        in appsettings.json or other config to ensure the application can connect properly.
+      # - name: Update sql connection string
+      #   uses: im-open/variable-substitution@v2
+      #   with:
+      #     files: '' # TOD:  add file path to appsettings.json
+      #   env:
+      #     ConnectionStrings.<<PROJECT>>: 'Server=localhost;Database=${{ env.DB_NAME }};Trusted_Connection=False;User ID=SA;Password=${{ env.SQL_SERVER_PASSWORD }}' # TODO:  Verify connectionString name for app setting and any additional properties that need to be added
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
@@ -326,7 +344,7 @@ jobs:
   # TODO: Remove this job if you do not have jest tests
 
   jest:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow, npm-cache]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
 
@@ -433,7 +451,7 @@ jobs:
           path: ${{ env.CODE_COVERAGE_DIR_JEST }}
 
   build-deployment-artifacts:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow, npm-cache, nuget-cache]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true' && needs.setup-build-workflow.outputs.CREATE_RELEASE == 'true'
 

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v33    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v34    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -51,7 +51,7 @@ jobs:
       # workflow-summary : | # TODO:  If desired, the workflow summary that is generated can be overridden by providing this custom value.
 
   build-test-publish:
-    runs-on: [self-hosted, ubuntu-20.04] # TODO: decide whether to run on a self-hosted runner. It's only necessary if pushing the package to Artifactory.
+    runs-on: [self-hosted, im-linux]
     needs: [setup-build-workflow]
     if: needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
 

--- a/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
+++ b/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DeterminedPorcupine_v18    DO NOT REMOVE
+# Workflow Code: DeterminedPorcupine_v19    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform plan against the specified environments and
 #    comments on the PR with the expected changes when commits are pushed to a PR.
@@ -22,7 +22,7 @@ on:
 
 jobs:
   auto-plan-the-tf:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     strategy:
       matrix:

--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmbitiousLizard_v41    DO NOT REMOVE
+# Workflow Code: AmbitiousLizard_v42    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified
@@ -200,7 +200,7 @@ jobs:
 
   deploy-code:
     needs: [set-vars, stakeholder-approval, attestor-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
 
     env:

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v25    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v26    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -156,7 +156,7 @@ jobs:
 
   deploy-az-db:
     needs: [set-vars, stakeholder-approval, attestor-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
     outputs:
       DB_NAME: ${{ steps.db-vars.outputs.DB_NAME }}

--- a/workflow-templates/im-deploy-az-swap-app-slots.yml
+++ b/workflow-templates/im-deploy-az-swap-app-slots.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritatedHyena_v17    DO NOT REMOVE
+# Workflow Code: IrritatedHyena_v18    DO NOT REMOVE
 # Purpose:
 #    Swaps deployment slots in a specified environment for an Azure App Service
 #    or Function outside of a deployment when someone kicks it off manually.
@@ -45,7 +45,7 @@ on:
 
 jobs:
   swap-slots:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment || github.event.client_payload.environment }}
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window

--- a/workflow-templates/im-deploy-files-to-az-storage-account.yml
+++ b/workflow-templates/im-deploy-files-to-az-storage-account.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BubblyGreyhound_v21    DO NOT REMOVE
+# Workflow Code: BubblyGreyhound_v22    DO NOT REMOVE
 # Purpose:
 #    Checks out the repository and deploys a directory to the
 #    specified storage account when someone kicks it off manually.
@@ -45,7 +45,7 @@ env:
 
 jobs:
   deploy-to-azure:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -219,7 +219,7 @@ jobs:
         stakeholder-approval,
         attestor-approval
       ]
-    runs-on: [self-hosted, windows-2019]
+    runs-on: [self-hosted, windows-2019] # In order to use WinRM this must remain as a windows runner
     environment: ${{ inputs.environment }} # Use inputs context because env context is not available to 'environment:'
 
     strategy:

--- a/workflow-templates/im-deploy-multiple-items-at-once.yml
+++ b/workflow-templates/im-deploy-multiple-items-at-once.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MercifulLlama_v14    DO NOT REMOVE
+# Workflow Code: MercifulLlama_v15    DO NOT REMOVE
 # Purpose:
 #    This is only required when teams have separate deployable artifacts (db/mfe/api/etc.)
 #    but they need each item to be deployed together.
@@ -83,7 +83,7 @@ jobs:
 
   initiate-deployments:
     needs: [stakeholder-approval, attestor-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     steps:
       - run: echo "The current environment is ${{ env.ENVIRONMENT }}.  The Tag is ${{ env.RELEASE_TAG }}."

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v26    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v27    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -104,7 +104,7 @@ jobs:
 
   deploy-on-prem-db:
     needs: [stakeholder-approval, attestor-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ inputs.environment }} # Use inputs context because env context is not available to environment:
     outputs:
       DB_NAME: ${{ steps.environment-specific-vars.outputs.DB_NAME }}

--- a/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
+++ b/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritableEagle_v27    DO NOT REMOVE
+# Workflow Code: IrritableEagle_v28    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform apply -auto-approve with the changes
 #    in the PR against the dev environment when a PR is merged to main.
@@ -49,7 +49,7 @@ jobs:
   auto-apply-tf:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' # TODO: verify default branch name
 
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     environment: 'Dev'
 

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v37    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v38    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -150,7 +150,7 @@ jobs:
 
   tf-plan:
     needs: [set-vars, stakeholder-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
     env:
       PAGERDUTY_WINDOW_IN_MIN: 30 # TODO: Verify the length of your PD Maintenance Window
@@ -276,7 +276,7 @@ jobs:
 
   tf-apply:
     needs: [set-vars, tf-plan, tf-plan-manual-approval, stakeholder-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
 
     defaults:

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -109,7 +109,7 @@ jobs:
     needs: |
       - stakeholder-approval
       - attestor-approval
-    runs-on: [self-hosted, windows-2019]
+    runs-on: [self-hosted, windows-2019] # In order to use WinRM this must remain as a windows runner
     environment: ${{ inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -178,7 +178,7 @@ jobs:
       - set-vars
       - stakeholder-approval
       - attestor-approval
-    runs-on: [self-hosted, windows-2019]
+    runs-on: [self-hosted, windows-2019] # In order to use WinRM this must remain as a windows runner
     environment: ${{ inputs.environment }} # Use inputs context because env context is not available to environment:
 
     strategy:

--- a/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
+++ b/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
@@ -1,4 +1,4 @@
-# Workflow Code: CockySquirrel_v12    DO NOT REMOVE
+# Workflow Code: CockySquirrel_v13    DO NOT REMOVE
 # Purpose:
 #    Adds or updates an azure KeyVault secret in the specified
 #    environment when someone kicks it off manually.
@@ -39,7 +39,7 @@ on:
 
 jobs:
   set-secret:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     environment: ${{ github.event.inputs.environment }}
 

--- a/workflow-templates/im-run-annotate-app-insights.yml
+++ b/workflow-templates/im-run-annotate-app-insights.yml
@@ -1,4 +1,4 @@
-# Workflow Code: EmpatheticDolphin_v14    DO NOT REMOVE
+# Workflow Code: EmpatheticDolphin_v15    DO NOT REMOVE
 # Purpose:
 #    Creates an ad hoc app insights annotation for a specified
 #    environment when someone kicks it off manually.
@@ -49,7 +49,7 @@ env:
 
 jobs:
   create-annotation:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }}
     steps:
       - run: |

--- a/workflow-templates/im-run-delete-azure-blob.yml
+++ b/workflow-templates/im-run-delete-azure-blob.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ScornfulFlamingo_v4   DO NOT REMOVE
+# Workflow Code: ScornfulFlamingo_v5   DO NOT REMOVE
 # Purpose:
 #    Deletes a blob from a specified Azure Storage Account when someone kicks it off manually.
 #
@@ -42,7 +42,7 @@ on:
 
 jobs:
   delete-blob:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     environment: ${{ github.event.inputs.environment }}
 

--- a/workflow-templates/im-run-flyway-repair.yml
+++ b/workflow-templates/im-run-flyway-repair.yml
@@ -1,4 +1,4 @@
-# Workflow Code: SpiritedGnat_v16    DO NOT REMOVE
+# Workflow Code: SpiritedGnat_v17    DO NOT REMOVE
 # Purpose:
 #    Runs a flyway repair command against an Azure SQL or
 #    On-Prem Database when someone kicks it off manually.
@@ -44,7 +44,7 @@ env:
 
 jobs:
   repair-database-migrations:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
     steps:
       - run: |

--- a/workflow-templates/im-run-start-stop-restart-azure-app.yml
+++ b/workflow-templates/im-run-start-stop-restart-azure-app.yml
@@ -1,4 +1,4 @@
-# Workflow Code: NeedyPig_v13    DO NOT REMOVE
+# Workflow Code: NeedyPig_v14    DO NOT REMOVE
 # Purpose:
 #    Performs a start, stop or restart on an app service in the
 #    specified environment when someone kicks it off manually.
@@ -46,7 +46,7 @@ env:
 
 jobs:
   start-stop-restart:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     env:

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v16    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v17    DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -142,7 +142,7 @@ jobs:
 
   tf-plan:
     needs: [set-vars, stakeholder-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
 
     defaults:
@@ -255,7 +255,7 @@ jobs:
 
   tf-apply:
     needs: [set-vars, tf-plan, tf-plan-manual-approval, stakeholder-approval]
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }}
 
     defaults:

--- a/workflow-templates/im-run-tf-import.yml
+++ b/workflow-templates/im-run-tf-import.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DrearyBuck_v16    DO NOT REMOVE
+# Workflow Code: DrearyBuck_v17    DO NOT REMOVE
 
 # Purpose:
 #    Imports a specified resource into the terraform state when someone kicks it off manually.
@@ -61,7 +61,7 @@ env:
 
 jobs:
   tf-import-state:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:

--- a/workflow-templates/im-run-tf-taint.yml
+++ b/workflow-templates/im-run-tf-taint.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GratefulTermite_v13    DO NOT REMOVE
+# Workflow Code: GratefulTermite_v14    DO NOT REMOVE
 # Purpose:
 #    Taints a specified terraform resource when someone kicks it off manually.
 #
@@ -57,7 +57,7 @@ env:
 
 jobs:
   tf-taint-resource:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:

--- a/workflow-templates/im-run-unlock-tf-state.yml
+++ b/workflow-templates/im-run-unlock-tf-state.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FrazzledFerret_v19    DO NOT REMOVE
+# Workflow Code: FrazzledFerret_v20    DO NOT REMOVE
 # Purpose:
 #    Removes a lock from the terraform state when someone kicks it off manually.
 #
@@ -57,7 +57,7 @@ env:
 
 jobs:
   tf-unlock-state:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     environment: ${{ github.event.inputs.environment }} # Use inputs context because env context is not available to environment:
 
     defaults:

--- a/workflow-templates/im-run-validate-deployed-terraform.yml
+++ b/workflow-templates/im-run-validate-deployed-terraform.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ShinySQUIRREL_v19    DO NOT REMOVE
+# Workflow Code: ShinySQUIRREL_v20    DO NOT REMOVE
 # Purpose:
 #    Validates that the deployed terraform matches what is supposed to be deployed
 #    when it runs at a scheduled time or when someone kicks it off manually.
@@ -28,7 +28,7 @@ on:
 
 jobs:
   auto-plan-the-tf:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     strategy:
       matrix:

--- a/workflow-templates/im-test-k6-ci.yml
+++ b/workflow-templates/im-test-k6-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TroubledJaguar_v3    DO NOT REMOVE
+# Workflow Code: TroubledJaguar_v4    DO NOT REMOVE
 # Purpose: 
 #    Uses a container to run K6 with the file specified in 
 #    the workflow when commits are pushed to the main branch.
@@ -39,7 +39,7 @@ env:
 
 jobs:
   k6_test:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     steps:
       - name: Checkout

--- a/workflow-templates/im-test-k6-manual.yml
+++ b/workflow-templates/im-test-k6-manual.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyFlamingo_v19    DO NOT REMOVE
+# Workflow Code: ZestyFlamingo_v20    DO NOT REMOVE
 # Purpose:
 #    Uses a container to run a K6 stress test against the environment and
 #    with the test file the user specifies when they kick it off manually.
@@ -68,7 +68,7 @@ env:
 
 jobs:
   matrix-setup:
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, im-linux]
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -112,7 +112,7 @@ jobs:
             core.notice(`${output}`);
 
   k6_test:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [matrix-setup]
 
     defaults:

--- a/workflow-templates/im-test-k6-operator.yml
+++ b/workflow-templates/im-test-k6-operator.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyAligator_v17   DO NOT REMOVE
+# Workflow Code: ZestyAligator_v18   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -151,7 +151,7 @@ jobs:
 
       # This action creates a post-job step that will upload the node_modules dir to the cache if the job
       # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the node_modules
-      # folder if the package-lock.json hasn't changed and it uses a ubuntu-20.04 runner to restore the cache from.
+      # folder if the package-lock.json hasn't changed and it uses a im-linux runner to restore the cache from.
       # TODO: Delete if you don't build your k6 tests
       - name: Install Node ${{ env.NODE_VERSION }}
         if: steps.has-cache.outputs.cache-hit == 'false'
@@ -183,7 +183,7 @@ jobs:
           npm ci
 
   run_k6_operator:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
     needs: [npm-cache] # TODO: Delete if you don't build your k6 tests
     environment: ${{ inputs.env }}
 

--- a/workflow-templates/im-test-postman.yml
+++ b/workflow-templates/im-test-postman.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GuiltyBison_v12    DO NOT REMOVE
+# Workflow Code: GuiltyBison_v13    DO NOT REMOVE
 # Purpose:
 #    Runs the Postman script specified in the workflow when someone
 #    manually kicks it off or when another workflow triggers it.
@@ -38,7 +38,7 @@ env:
 
 jobs:
   run-postman:
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted, im-linux]
 
     defaults:
       run:


### PR DESCRIPTION
- Switch instances of `[self-hosted, ubuntu-20.04]` to `[self-hosted, im-linux]`
- In db ci and dotnet ci workflows, setup the services for the jobs that use the sql server.  The im-linux runners do not contain this by default.