### PR TITLE
ARCH-1856 - Transition to vars context from secrets context

### DIFF
--- a/.github/workflows/im-reusable-finish-build-workflow.yml
+++ b/.github/workflows/im-reusable-finish-build-workflow.yml
@@ -117,7 +117,7 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Build
-          teams-uri: ${{ secrets.MS_TEAMS_URI }}
+          teams-uri: ${{ vars.MS_TEAMS_URI }}
           timezone: ${{ inputs.timezone }}
           custom-facts: ${{ steps.team-channel-facts.outputs.facts }}
       

--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -27,8 +27,8 @@
 #        { "name": "Version", "value": "${{ inputs.tag }}" }
 #      ]
 #    secrets:
-#      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}  
-#      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL}}
+#      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}  
+#      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL}}
 
 
 on:
@@ -146,7 +146,7 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Deploy
-          teams-uri: ${{ secrets.MS_TEAMS_URI }}
+          teams-uri: ${{ vars.MS_TEAMS_URI }}
           timezone: ${{ inputs.timezone }}
           custom-facts: ${{ steps.team-channel-facts.outputs.facts }}
 
@@ -209,7 +209,7 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Deploy
-          teams-uri: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+          teams-uri: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
           timezone: ${{ inputs.timezone }}
           include-default-facts: false # This cuts down on the message size for the prod room
           custom-facts: ${{ steps.deployment-channel-facts.outputs.facts }}

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v43    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v44    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -614,4 +614,4 @@ jobs:
       #     { "name": "Version", "value": "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-build-npm-package.yml
+++ b/workflow-templates/im-build-npm-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GloomyBadger_v29    DO NOT REMOVE
+# Workflow Code: GloomyBadger_v30    DO NOT REMOVE
 # Purpose:
 #    Automatically calculates the next semantic version, runs an npm ci, an npm run tests
 #    if there is one, an npm publish and then pushes a latest tag for main builds. When the
@@ -157,4 +157,4 @@ jobs:
       #   ]
       
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v34    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v35    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -226,4 +226,4 @@ jobs:
       #   ]
       
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
+++ b/workflow-templates/im-build-tf-auto-plan-and-comment-on-prs.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DeterminedPorcupine_v19    DO NOT REMOVE
+# Workflow Code: DeterminedPorcupine_v20    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform plan against the specified environments and
 #    comments on the PR with the expected changes when commits are pushed to a PR.
@@ -32,11 +32,11 @@ jobs:
     environment: ${{ matrix.environment }}
 
     env:
-      # The following ARM_* secrets are org-level secrets
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      # The following ARM_* values are env-level secrets/variables
+      ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+      ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
       ARM_ENVIRONMENT: 'public'
       TF_IN_AUTOMATION: 'true'
       TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.

--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmbitiousLizard_v42    DO NOT REMOVE
+# Workflow Code: AmbitiousLizard_v43    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified
@@ -278,7 +278,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an org-level secret
           description: '${{ env.PAGERDUTY_WINDOW_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       - name: AZ Login
@@ -304,14 +304,14 @@ jobs:
       #     }
 
       # TODO: Uncomment if you want to create a slot to deploy to.  Delete if you have a permanent slot or do not wish to use slots.
-      # ARM_SUBSCRIPTION_ID is an env-level secret
+      # ARM_SUBSCRIPTION_ID is an env-level variable
       # - name: Create a deployment slot
       #   run: |
       #     az ${{ env.AZ_APP_TYPE }} deployment slot create \
       #     --name ${{ needs.set-vars.outputs.AZ_APP_NAME }}  \
       #     --slot ${{ env.AZ_SLOT_NAME }} \
       #     --resource-group ${{ needs.set-vars.outputs.TARGET_RESOURCE_GROUP }} \
-      #     --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} \
+      #     --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} \
       #     --configuration-source ${{ needs.set-vars.outputs.AZ_APP_NAME }}
 
       # TODO: Uncomment if you use User Managed Identity in your app service.
@@ -322,7 +322,7 @@ jobs:
       #       --name ${{ needs.set-vars.outputs.AZ_APP_NAME }} \
       #       --resource-group ${{ needs.set-vars.outputs.TARGET_RESOURCE_GROUP }} \
       #       --slot ${{ env.AZ_SLOT_NAME }} \
-      #       --identities /subscriptions/${{ secrets.ARM_SUBSCRIPTION_ID }}/resourcegroups/${{ needs.set-vars.outputs.PRIMARY_RESOURCE_GROUP }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${{ needs.set-vars.outputs.AZ_APP_MSI }}
+      #       --identities /subscriptions/${{ vars.ARM_SUBSCRIPTION_ID }}/resourcegroups/${{ needs.set-vars.outputs.PRIMARY_RESOURCE_GROUP }}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${{ needs.set-vars.outputs.AZ_APP_MSI }}
 
       # TODO Uncomment if you require networking on bootstrap of application.  IE Eventhub, Hashicorp Vault
       # - name: Assign VNet to slot
@@ -352,23 +352,23 @@ jobs:
           slot-name: ${{ env.AZ_SLOT_NAME }} # TODO: Delete if not using slots
 
       # TODO: Uncomment if using slots and you want to swap them now (as opposed to doing it in another workflow).  Delete this block if you don't.
-      # ARM_SUBSCRIPTION_ID is an env-level secret
+      # ARM_SUBSCRIPTION_ID is an env-level variable
       # - name: Swap slots
       #   run: |
       #     az ${{ env.AZ_APP_TYPE }} deployment slot swap \
-      #     --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} \
+      #     --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} \
       #     --resource-group ${{ needs.set-vars.outputs.TARGET_RESOURCE_GROUP }} \
       #     --name ${{ needs.set-vars.outputs.AZ_APP_NAME }}  \
       #     --slot ${{ env.AZ_SLOT_NAME }} \
       #     --target-slot ${{ env.TARGET_SLOT }}
 
       # TODO: Uncomment if you want to delete the temporary slot.  Delete this block if you don't.
-      # ARM_SUBSCRIPTION_ID is an env-level secret
+      # ARM_SUBSCRIPTION_ID is an env-level variable
       # - run: |
       #     az ${{ env.AZ_APP_TYPE }} deployment slot delete \
       #     --slot ${{ env.AZ_SLOT_NAME }} \
       #     --name ${{ needs.set-vars.outputs.AZ_APP_NAME }}  \
-      #     --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} \
+      #     --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} \
       #     --resource-group ${{ needs.set-vars.outputs.TARGET_RESOURCE_GROUP }}
 
       # TODO: Uncomment if you have azure locks in stage and prod
@@ -389,7 +389,7 @@ jobs:
       - name: Annotate App Insights
         uses: im-open/create-app-insights-annotation@v1.0
         with:
-          subscriptionId: ${{ secrets.ARM_SUBSCRIPTION_ID }} # This is an env-level secret
+          subscriptionId: ${{ vars.ARM_SUBSCRIPTION_ID }} # This is an env-level variable
           resourceGroupName: ${{ needs.set-vars.outputs.PRIMARY_RESOURCE_GROUP }}
           appInsightsResourceName: '${{ needs.set-vars.outputs.APP_INSIGHTS_NAME }}'
           releaseName: '${{ needs.set-vars.outputs.AZ_APP_NAME }}-${{ env.RELEASE_TAG }}'
@@ -461,5 +461,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v26    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v27    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -238,7 +238,7 @@ jobs:
       - name: Annotate App Insights
         uses: im-open/create-app-insights-annotation@v1.0
         with:
-          subscriptionId: ${{ secrets.ARM_SUBSCRIPTION_ID }} # This is an env-level secret
+          subscriptionId: ${{ vars.ARM_SUBSCRIPTION_ID }} # This is an env-level variable
           resourceGroupName: ${{ needs.set-vars.outputs.PRIMARY_RESOURCE_GROUP }}
           appInsightsResourceName: '${{ needs.set-vars.outputs.APP_INSIGHTS_NAME }}'
           releaseName: '${{ needs.set-vars.outputs.APP_INSIGHTS_ANNOTATION }}'
@@ -287,5 +287,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag == 0 && github.ref_name || inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}    
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}    

--- a/workflow-templates/im-deploy-az-swap-app-slots.yml
+++ b/workflow-templates/im-deploy-az-swap-app-slots.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritatedHyena_v18    DO NOT REMOVE
+# Workflow Code: IrritatedHyena_v19    DO NOT REMOVE
 # Purpose:
 #    Swaps deployment slots in a specified environment for an Azure App Service
 #    or Function outside of a deployment when someone kicks it off manually.
@@ -97,7 +97,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an org-level secret
           description: '${{ env.PAGERDUTY_WINDOW_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       - name: AZ Login
@@ -107,22 +107,22 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }} # This is an env-level secret
 
       - name: Swap
-        # ARM_SUBSCRIPTION_ID is an env-level secret
+        # ARM_SUBSCRIPTION_ID is an env-level variable
         run: |
           az ${{ env.AZ_APP_TYPE }} deployment slot swap \
-          --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} \
+          --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} \
           --resource-group ${{ env.RESOURCE_GROUP }} \
           --name ${{ env.AZ_APP_NAME }}  \
           --slot ${{ env.SOURCE_SLOT }} \
           --target-slot ${{ env.TARGET_SLOT }}
 
       # TODO: Uncomment if you want to destroy the slot after swap.  Delete if you don't.
-      # ARM_SUBSCRIPTION_ID is an env-level secret
+      # ARM_SUBSCRIPTION_ID is an env-level variable
       # - run: |
       #     az ${{ env.AZ_APP_TYPE }} deployment slot delete \
       #     --slot ${{ env.SOURCE_SLOT }} \
       #     --name ${{ env.AZ_APP_NAME }}  \
-      #     --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} \
+      #     --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} \
       #     --resource-group ${{ env.RESOURCE_GROUP }}
 
       - name: Azure logout

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FuzzyDragon_v39    DO NOT REMOVE
+# Workflow Code: FuzzyDragon_v40    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified environments,
@@ -259,7 +259,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an env-level secret
           description: '${{ env.PAGERDUTY_WINDOW_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       - name: Download artifacts from release
@@ -414,5 +414,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}    
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}    

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v27    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v28    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -228,5 +228,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}    
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}    

--- a/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
+++ b/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritableEagle_v28    DO NOT REMOVE
+# Workflow Code: IrritableEagle_v29    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform apply -auto-approve with the changes
 #    in the PR against the dev environment when a PR is merged to main.
@@ -25,11 +25,11 @@ env:
   TIMEZONE: 'america/denver' # TODO: Verify timezone
   PAGERDUTY_WINDOW_IN_MIN: 10 # TODO: Verify the length of your PD Maintenance Window
   PAGERDUTY_WINDOW_DESC: 'Auto apply main branch to Dev environment from GitHub Actions' # TODO: Verify this description
-  # The following ARM_* secrets are env-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.4.0' #TODO:  Verify your version of terraform.
@@ -85,7 +85,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an org-level secret
           description: '${{ env.PAGERDUTY_WINDOW_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       # TODO: Remove the pagerduty token if not configuring pagerduty.  If using pagerduty verify 'pagerduty_token' is the name of the variable that tf expects
@@ -110,7 +110,7 @@ jobs:
           title: Auto-Deploying <project-name> Terraform to Dev # TODO: Replace <project-name> with your project
           workflow-status: ${{ job.status }}
           workflow-type: Deploy
-          teams-uri: ${{ secrets.MS_TEAMS_URI }} # This is a env-level secret (because 'environment:' has been added to the job).  If an env-level secret is not provided, it will look at the repo-level for the secret.
+          teams-uri: ${{ vars.MS_TEAMS_URI }} # This is a env-level variable (because 'environment:' has been added to the job).  If an env-level variable is not provided, it will look at the repo-level for the variable.
           timezone: ${{ env.TIMEZONE }}
           custom-facts: |
             [

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v38    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v39    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -39,11 +39,11 @@ env:
   DEPLOYMENT_DESC: 'Applying <project-name> ${{ inputs.root-module }} terraform at ${{ inputs.branch-tag-sha }} from GitHub Actions.' # TODO: Replace <project-name> with your project
   GITHUB_REF: ${{ inputs.branch-tag-sha  }} # This is the branch/tag/sha that we'll be deploying
   PLAN_STORAGE_CONTAINER: 'tfstate'
-  # The following ARM_* secrets are env-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.4.0' #TODO:  Verify your version of terraform.
@@ -183,7 +183,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an org-level secret
           description: '${{ env.DEPLOYMENT_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       - name: AZ Login
@@ -356,7 +356,7 @@ jobs:
       #   uses: im-open/create-app-insights-annotation@v1.0
       #   continue-on-error: true
       #   with:
-      #     subscriptionId: ${{ secrets.ARM_SUBSCRIPTION_ID }} # This is an env-level secret
+      #     subscriptionId: ${{ vars.ARM_SUBSCRIPTION_ID }} # This is an env-level variable
       #
       #     # The following line assumes the App insights resource is always in the primary region's resource group.
       #     # You might change this when App insights becomes available in our secondary region.
@@ -420,5 +420,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.branch-tag-sha  }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MysteriousStranger_v10    DO NOT REMOVE
+# Workflow Code: MysteriousStranger_v11    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -244,5 +244,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}    
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}    

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MaterialVolcano_v33    DO NOT REMOVE
+# Workflow Code: MaterialVolcano_v34    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -218,7 +218,7 @@ jobs:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an env-level secret
           description: '${{ env.PAGERDUTY_WINDOW_DESC }}'
           minutes: ${{ env.PAGERDUTY_WINDOW_IN_MIN }}
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           #service-ids: '' # TODO: Provide a comma separated list if there are multiple ids. 'PD01,PD02,PD03'
 
       # For more information and best practices on the usage and options available
@@ -373,5 +373,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}    
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}    

--- a/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
+++ b/workflow-templates/im-run-add-or-update-az-keyvault-secret.yml
@@ -1,4 +1,4 @@
-# Workflow Code: CockySquirrel_v13    DO NOT REMOVE
+# Workflow Code: CockySquirrel_v14    DO NOT REMOVE
 # Purpose:
 #    Adds or updates an azure KeyVault secret in the specified
 #    environment when someone kicks it off manually.
@@ -80,8 +80,8 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }} # This is an env-level secret
 
       - name: keyvault add or update secret
-        # ARM_SUBSCRIPTION_ID is an env-level secret
-        run: az keyvault secret set --name ${{ github.event.inputs.secret_name }} --vault-name ${{ env.KEYVAULT_NAME }} --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }} --value "${{ github.event.inputs.secret_value }}"
+        # ARM_SUBSCRIPTION_ID is an env-level variable
+        run: az keyvault secret set --name ${{ github.event.inputs.secret_name }} --vault-name ${{ env.KEYVAULT_NAME }} --subscription ${{ vars.ARM_SUBSCRIPTION_ID }} --value "${{ github.event.inputs.secret_value }}"
 
       - name: Azure logout
         if: always() && steps.login.outcome == 'success'

--- a/workflow-templates/im-run-annotate-app-insights.yml
+++ b/workflow-templates/im-run-annotate-app-insights.yml
@@ -1,4 +1,4 @@
-# Workflow Code: EmpatheticDolphin_v15    DO NOT REMOVE
+# Workflow Code: EmpatheticDolphin_v16    DO NOT REMOVE
 # Purpose:
 #    Creates an ad hoc app insights annotation for a specified
 #    environment when someone kicks it off manually.
@@ -93,7 +93,7 @@ jobs:
       - name: annotate
         uses: im-open/create-app-insights-annotation@v1.0
         with:
-          subscriptionId: ${{ secrets.ARM_SUBSCRIPTION_ID }} # This is an env-level secret
+          subscriptionId: ${{ vars.ARM_SUBSCRIPTION_ID }} # This is an env-level variable
           resourceGroupName: ${{ env.RESOURCE_GROUP }}
           appInsightsResourceName: '${{ env.APP_INSIGHTS_NAME }}'
           releaseName: ${{ github.event.inputs.eventName }}

--- a/workflow-templates/im-run-start-stop-restart-azure-app.yml
+++ b/workflow-templates/im-run-start-stop-restart-azure-app.yml
@@ -1,4 +1,4 @@
-# Workflow Code: NeedyPig_v14    DO NOT REMOVE
+# Workflow Code: NeedyPig_v15    DO NOT REMOVE
 # Purpose:
 #    Performs a start, stop or restart on an app service in the
 #    specified environment when someone kicks it off manually.
@@ -103,18 +103,18 @@ jobs:
 
       - name: start
         if: env.ACTION == 'start'
-        # ARM_SUBSCRIPTION_ID is an env-level secret
-        run: az ${{ env.AZ_APP_TYPE }} start --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }}
+        # ARM_SUBSCRIPTION_ID is an env-level variable
+        run: az ${{ env.AZ_APP_TYPE }} start --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ vars.ARM_SUBSCRIPTION_ID }}
 
       - name: stop
         if: env.ACTION == 'stop'
-        # ARM_SUBSCRIPTION_ID is an env-level secret
-        run: az ${{ env.AZ_APP_TYPE }} stop --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }}
+        # ARM_SUBSCRIPTION_ID is an env-level variable
+        run: az ${{ env.AZ_APP_TYPE }} stop --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ vars.ARM_SUBSCRIPTION_ID }}
 
       - name: restart
         if: env == 'restart'
-        # ARM_SUBSCRIPTION_ID is an env-level secret
-        run: az ${{ env.AZ_APP_TYPE }} restart --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ secrets.ARM_SUBSCRIPTION_ID }}
+        # ARM_SUBSCRIPTION_ID is an env-level variable
+        run: az ${{ env.AZ_APP_TYPE }} restart --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }} --subscription ${{ vars.ARM_SUBSCRIPTION_ID }}
 
       - name: Azure logout
         if: always() && steps.login.outcome == 'success'

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v17    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v18    DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -41,11 +41,11 @@ env:
   DEPLOYMENT_DESC: 'Destroying <project-name> ${{ inputs.tf-targets }} ${{ inputs.root-module }} via Terraform at ${{ inputs.branch-tag-sha }}' # TODO: Replace <project-name> with your project
   GITHUB_REF: ${{ inputs.branch-tag-sha  }}
   PLAN_STORAGE_CONTAINER: 'tfstate'
-  # The following ARM_* secrets are env-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.4.0' #TODO:  Verify your version of terraform.
@@ -378,5 +378,5 @@ jobs:
       #     { "name": "Version", "value": "${{ inputs.branch-tag-sha }}" }
       #   ]
     secrets:
-      MS_TEAMS_URI: ${{ secrets.MS_TEAMS_URI }} 
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }} 
+      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-run-tf-import.yml
+++ b/workflow-templates/im-run-tf-import.yml
@@ -1,4 +1,4 @@
-# Workflow Code: DrearyBuck_v17    DO NOT REMOVE
+# Workflow Code: DrearyBuck_v18    DO NOT REMOVE
 
 # Purpose:
 #    Imports a specified resource into the terraform state when someone kicks it off manually.
@@ -41,11 +41,11 @@ on:
 env:
   ENVIRONMENT: ${{ github.event.inputs.environment }}
   GITHUB_REF: ${{ github.event.inputs.branch-tag-sha  }}
-  # The following ARM_* secrets are org-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.

--- a/workflow-templates/im-run-tf-taint.yml
+++ b/workflow-templates/im-run-tf-taint.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GratefulTermite_v14    DO NOT REMOVE
+# Workflow Code: GratefulTermite_v15    DO NOT REMOVE
 # Purpose:
 #    Taints a specified terraform resource when someone kicks it off manually.
 #
@@ -37,11 +37,11 @@ on:
 env:
   ENVIRONMENT: ${{ github.event.inputs.environment }}
   GITHUB_REF: ${{ github.event.inputs.branch-tag-sha  }}
-  # The following ARM_* secrets are org-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.

--- a/workflow-templates/im-run-unlock-tf-state.yml
+++ b/workflow-templates/im-run-unlock-tf-state.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FrazzledFerret_v20    DO NOT REMOVE
+# Workflow Code: FrazzledFerret_v21    DO NOT REMOVE
 # Purpose:
 #    Removes a lock from the terraform state when someone kicks it off manually.
 #
@@ -37,11 +37,11 @@ on:
 env:
   ENVIRONMENT: ${{ github.event.inputs.environment }}
   GITHUB_REF: ${{ github.event.inputs.branch-tag-sha  }}
-  # The following ARM_* secrets are org-level secrets
-  ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-  ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+  # The following ARM_* values are env-level secrets/variables
+  ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+  ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-  ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+  ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
   ARM_ENVIRONMENT: 'public'
   TF_IN_AUTOMATION: 'true'
   TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.

--- a/workflow-templates/im-run-validate-deployed-terraform.yml
+++ b/workflow-templates/im-run-validate-deployed-terraform.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ShinySQUIRREL_v20    DO NOT REMOVE
+# Workflow Code: ShinySQUIRREL_v21    DO NOT REMOVE
 # Purpose:
 #    Validates that the deployed terraform matches what is supposed to be deployed
 #    when it runs at a scheduled time or when someone kicks it off manually.
@@ -38,11 +38,11 @@ jobs:
     environment: ${{ matrix.environment }}
 
     env:
-      # The following ARM_* secrets are org-level secrets
-      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+      # The following ARM_* values are env-level secrets/variables
+      ARM_SUBSCRIPTION_ID: ${{ vars.ARM_SUBSCRIPTION_ID }}
+      ARM_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
       ARM_ENVIRONMENT: 'public'
       TF_IN_AUTOMATION: 'true'
       TF_VERSION: '~>1.0.5' #TODO:  Verify your version of terraform.
@@ -153,7 +153,7 @@ jobs:
         uses: im-open/create-pagerduty-incident@v1.1
         with:
           pagerduty-api-key: ${{ secrets.PAGERDUTY_API_KEY }} # This is an org-level secret
-          service-id: ${{ secrets.PAGERDUTY_SERVICE_ID }} # This is an env-level secret
+          service-id: ${{ vars.PAGERDUTY_SERVICE_ID }} # This is an env-level variable
           email: 'svc-hubot@extendhealth.com'
           title: 'Your terraform does not match what was expected!'
           body: 'The workflow found changes in the ${{matrix.environment}} environment.  The workflow expected the infrastructure to match the terraform at ${{ steps.get-latest.outputs.VERSION }}.  See workflow run at ${{ env.REPO_URL }}/actions/runs/${{ github.run_id }} for more details.'

--- a/workflow-templates/im-test-cypress.yml
+++ b/workflow-templates/im-test-cypress.yml
@@ -1,4 +1,4 @@
-# Workflow Code: SurprisedHedgehog_v15    DO NOT REMOVE
+# Workflow Code: SurprisedHedgehog_v16    DO NOT REMOVE
 # Purpose:
 #    Runs the Cypress script specified in the workflow when commits
 #    are pushed to the PR or when someone kicks it off manually.
@@ -63,9 +63,9 @@ jobs:
     #        ensures your app can connect to azure resources without clashing with the runner machine's azure identity.
     #        If your tests do not need to connect to Azure, these environment variables can be removed.
     # env:
-    #   AZURE_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+    #   AZURE_CLIENT_ID: ${{ vars.ARM_CLIENT_ID }}
     #   AZURE_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-    #   AZURE_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+    #   AZURE_TENANT_ID: ${{ vars.ARM_TENANT_ID }} # This is an org-level variable
 
     steps:
       - uses: actions/checkout@v3

--- a/workflow-templates/im-test-k6-manual.yml
+++ b/workflow-templates/im-test-k6-manual.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyFlamingo_v20    DO NOT REMOVE
+# Workflow Code: ZestyFlamingo_v21    DO NOT REMOVE
 # Purpose:
 #    Uses a container to run a K6 stress test against the environment and
 #    with the test file the user specifies when they kick it off manually.
@@ -215,7 +215,7 @@ jobs:
           title: 'K6 Test for <your project> - ${{ github.event.inputs.run-name }}' # TODO: Update
           workflow-status: ${{ steps.k6-run.outcome }}
           workflow-type: Runbook
-          teams-uri: ${{ secrets.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
+          teams-uri: ${{ vars.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
           timezone: ${{ env.TIMEZONE }}
           custom-facts: |
             [

--- a/workflow-templates/im-test-k6-operator.yml
+++ b/workflow-templates/im-test-k6-operator.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyAligator_v18   DO NOT REMOVE
+# Workflow Code: ZestyAligator_v19   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -258,7 +258,7 @@ jobs:
           title: 'K6 Test Starting Shortly in AKS - ${{inputs.run-name }}'
           workflow-status: started
           workflow-type: Runbook
-          teams-uri: ${{ secrets.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
+          teams-uri: ${{ vars.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
           timezone: ${{ env.TIMEZONE }}
           custom-facts: |
             [
@@ -364,7 +364,7 @@ jobs:
           title: 'K6 Test in AKS Complete - ${{ inputs.run-name }}'
           workflow-status: ${{ steps.run-k6-operator-test.outcome }}
           workflow-type: Runbook
-          teams-uri: ${{ secrets.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
+          teams-uri: ${{ vars.MS_TEAMS_URI }} # This is a repo-level secret (unless 'environment:' has been added to the job)
           timezone: ${{ env.TIMEZONE }}
           custom-facts: |
             [


### PR DESCRIPTION
Update templates to use vars context where appropriate instead of secrets.  This applies to:

- DEPLOY_NOTIFICATIONS_CHANNEL
- MS_TEAMS_URI
- PAGERDUTY_SERVICE_ID
- ARM_TENANT_ID
- ARM_CLIENT_ID
- ARM_SUBSCRIPTION_ID 

