### PR TITLE
Remove the runs-on keyword from reusable workflow jobs.

### DIFF
--- a/.github/workflows/im-reusable-setup-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-setup-deployment-workflow.yml
@@ -30,7 +30,7 @@ on:
         required: false
         type: string
         default: 'prod,prod-secondary'      
-      verify-release-production-ready:
+      verify-release-is-production-ready:
           description: Verify associated release is not draft or prerelease
           required: false
           type: boolean
@@ -114,7 +114,7 @@ jobs:
           error-if-not-reachable: true  # This only runs for prod environments, so if the tag is not in main, it should fail
 
       - uses: im-open/is-release-production-ready@v1
-        if: steps.check-env.outputs.IS_PROD == 'true' && inputs.verify-release-production-ready == 'true'
+        if: steps.check-env.outputs.IS_PROD == 'true' && inputs.verify-release-is-production-ready == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ inputs.ref-to-deploy }}

--- a/.github/workflows/im-reusable-setup-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-setup-deployment-workflow.yml
@@ -30,7 +30,7 @@ on:
         required: false
         type: string
         default: 'prod,prod-secondary'      
-      verify-release-is-production-ready:
+      verify-release-production-ready:
           description: Verify associated release is not draft or prerelease
           required: false
           type: boolean
@@ -114,7 +114,7 @@ jobs:
           error-if-not-reachable: true  # This only runs for prod environments, so if the tag is not in main, it should fail
 
       - uses: im-open/is-release-production-ready@v1
-        if: steps.check-env.outputs.IS_PROD == 'true' && inputs.verify-release-is-production-ready == 'true'
+        if: steps.check-env.outputs.IS_PROD == 'true' && inputs.verify-release-production-ready == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ inputs.ref-to-deploy }}

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -80,7 +80,7 @@ jobs:
     with:
       ref-to-deploy: ${{ inputs.tag == 0 && github.ref_name || inputs.tag }}
       deployment-environment: ${{ inputs.environment-or-target }}
-      verify-release-is-production-ready: false # Set to false since db projects generally do not have an associated release
+      verify-release-production-ready: false # Set to false since db projects generally do not have an associated release
       # production-environments: 'prod,prod-secondary'  # TODO:  Adjust and include the production-environments if necessary (some apps may need to add stage/stage-secondary to this list)
       # default-branch: main # TODO:  Update and include this arg if the default branch is not main
       # workflow-summary : | # TODO:  If desired, the workflow summary that is generated can be overridden by providing this custom value.

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v29    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v30    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -270,7 +270,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [set-vars, deploy-az-db]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FuzzyDragon_v42    DO NOT REMOVE
+# Workflow Code: FuzzyDragon_v43    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified environments,
@@ -394,7 +394,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [set-vars, deploy-site-to-machine]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v30    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v31    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -210,7 +210,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [deploy-on-prem-db]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -82,7 +82,7 @@ jobs:
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}
-      verify-release-is-production-ready: false # Set to false since db projects generally do not have an associated release
+      verify-release-production-ready: false # Set to false since db projects generally do not have an associated release
       # production-environments: 'prod,prod-secondary'  # TODO:  Adjust and include the production-environments if necessary (some apps may need to add stage/stage-secondary to this list)
       # default-branch: main # TODO:  Update and include this arg if the default branch is not main
       # workflow-summary : | # TODO:  If desired, the workflow summary that is generated can be overridden by providing this custom value.

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v42    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v43    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -404,7 +404,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [set-vars, tf-apply]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -76,7 +76,7 @@ jobs:
     with:
       ref-to-deploy: ${{ inputs.branch-tag-sha }}
       deployment-environment: ${{ inputs.root-module }}
-      verify-release-is-production-ready: false # Set to false since terraform projects generally do not have an associated release
+      verify-release-production-ready: false # Set to false since terraform projects generally do not have an associated release
       # production-environments: 'prod,prod-secondary'  # TODO:  Adjust and include the production-environments if necessary (some apps may need to add stage/stage-secondary to this list)
       # default-branch: main # TODO:  Update and include this arg if the default branch is not main
       # workflow-summary : | # TODO:  If desired, the workflow summary that is generated can be overridden by providing this custom value.

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MysteriousStranger_v13    DO NOT REMOVE
+# Workflow Code: MysteriousStranger_v14    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -214,7 +214,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [setup-deployment-workflow, deploy-files]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MaterialVolcano_v36    DO NOT REMOVE
+# Workflow Code: MaterialVolcano_v37    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -353,7 +353,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [set-vars, deploy-service-to-machine]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -78,7 +78,7 @@ jobs:
     with:
       ref-to-deploy: ${{ inputs.branch-tag-sha }}
       deployment-environment: ${{ inputs.root-module }}
-      verify-release-is-production-ready: false # Set to false since terraform projects generally do not have an associated release
+      verify-release-production-ready: false # Set to false since terraform projects generally do not have an associated release
       # production-environments: 'prod,prod-secondary'  # TODO:  Adjust and include the production-environments if necessary (some apps may need to add stage/stage-secondary to this list)
       # default-branch: main # TODO:  Update and include this arg if the default branch is not main
       # workflow-summary : | # TODO:  If desired, the workflow summary that is generated can be overridden by providing this custom value.

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v21    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v22    DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -362,7 +362,6 @@ jobs:
   #  2 - Post a deployment status in the repo owner's Teams channel (connected to the MS_TEAMS_URI secret)
   #  3 - Post a deployment status in the Deployment Notifications Teams channel if the deploy is for prod, is successful and the flag to do so is not set to false
   update-deployment-board-and-send-teams-notification:
-    runs-on: ubuntu-latest # Force this to run on github-hosted runner by using a tag that does not exist on self-hosted runners
     needs: [set-vars, tf-apply]
     if: always()
     uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2


### PR DESCRIPTION
The runs-on is defined inside the job, so it shouldn't be included in the caller workflow.