### PR TITLE
ARCH-1919 - Updating cache check action

### DIFF
--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v46    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v47    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -88,38 +88,41 @@ jobs:
 
       - name: Check for an npm cache
         id: has-cache
-        uses: im-open/check-for-cache@v1.1
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ env.NPM_CACHE_KEY }}
+          lookup-only: true
+          enableCrossOsArchive: true
 
       # The remaining steps will only be executed if the cache was not found, otherwise they will be skipped.
 
-      # This action creates a post-job step that will upload the node_modules dir to the cache if the job
-      # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the node_modules
-      # folder if the package-lock.json hasn't changed and it uses a im-linux runner to restore the cache from.
-      - name: Setup caching for node_modules directory
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      # This action creates a post-job step that will upload the node_modules dir to the cache if the job completes successfully
+      - name: Setup caching for node_modules directory if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         with:
           key: ${{ env.NPM_CACHE_KEY }}
           path: '**/node_modules'
+          enableCrossOsArchive: true
 
-      - uses: actions/setup-node@v3
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: Setup node if cache does not exist
+        uses: actions/setup-node@v3
+        if: steps.has-cache.outputs.cache-hit != 'true'
         with:
           node-version: '16'
 
       # TODO:  If the project contains internal npm packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   if: steps.has-cache.outputs.cache-hit == 'false'
+      # - name: Authenticate with GitHub Packages if cache does not exist
+      #   if: steps.has-cache.outputs.cache-hit != 'true'
       #   uses: im-open/authenticate-with-gh-package-registries@v1.0
       #   with:
       #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
       #     orgs: ''
 
-      - run: npm ci
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: npm install if cache does not exist
+        run: npm ci
+        if: steps.has-cache.outputs.cache-hit != 'true'
 
   nuget-cache:
     runs-on: [self-hosted, im-linux]
@@ -149,25 +152,26 @@ jobs:
 
       - name: Check for a nuget cache
         id: has-cache
-        uses: im-open/check-for-cache@v1.1
+        uses: actions/cache@v3
         with:
           path: '~/.nuget/packages'
           key: ${{ env.NUGET_CACHE_KEY }}
+          lookup-only: true
+          enableCrossOsArchive: true
 
       # The remaining steps will only be executed if the cache was not found, otherwise they will be skipped.
 
-      # This action creates a post-job step that will upload the ./.nuget/packages dir to the cache if the job
-      # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the ./.nuget/packages
-      # folder if the csproj files haven't changed and it uses a im-linux runner to restore the cache from.
-      - name: Setup caching for nuget packages
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      # This action creates a post-job step that will upload the ./.nuget/packages dir to the cache if the job completes successfully
+      - name: Setup caching for nuget packages if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v3
         with:
           key: ${{ env.NUGET_CACHE_KEY }}
           path: ~/.nuget/packages
+          enableCrossOsArchive: true
 
-      - name: Setup .NET Core
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: Setup .NET Core if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
@@ -175,15 +179,16 @@ jobs:
           DOTNET_INSTALL_DIR: './.dotnet'
 
       # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   if: steps.has-cache.outputs.cache-hit == 'false'
+      # - name: Authenticate with GitHub Packages if cache does not exist
+      #   if: steps.has-cache.outputs.cache-hit != 'true'
       #   uses: im-open/authenticate-with-gh-package-registries@v1.0
       #   with:
       #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
       #     orgs: ''
 
-      - run: dotnet restore ${{ env.SOLUTION_FILE }}
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: dotnet restore if cache does not exist
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+        if: steps.has-cache.outputs.cache-hit != 'true'
 
   dotnet-test:
     runs-on: [self-hosted, im-linux]

--- a/workflow-templates/im-test-k6-operator-approval.yml
+++ b/workflow-templates/im-test-k6-operator-approval.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyCrocodile_v5   DO NOT REMOVE
+# Workflow Code: ZestyCrocodile_v6   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -136,25 +136,26 @@ jobs:
 
       - name: Check for an npm cache
         id: has-cache
-        uses: im-open/check-for-cache@v1.1.2
+        uses: actions/cache@v3.2.6
         with:
           path: '**/k6/node_modules'
           key: ${{ env.NPM_CACHE_KEY }}
+          lookup-only: true
+          enableCrossOsArchive: true
+
 
       # The remaining steps will only be executed if the cache was not found, otherwise they will be skipped.
 
-      # This action creates a post-job step that will upload the node_modules dir to the cache if the job
-      # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the node_modules
-      # folder if the package-lock.json hasn't changed and it uses a im-linux runner to restore the cache from.
+      # This action creates a post-job step that will upload the node_modules dir to the cache if the job completes succesfully
       # TODO: Delete if you don't build your k6 tests
       - name: Install Node ${{ env.NODE_VERSION }}
-        if: steps.has-cache.outputs.cache-hit == 'false'
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup caching for node_modules directory
-        if: steps.has-cache.outputs.cache-hit == 'false'
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/cache@v3.2.6
         with:
           key: ${{ env.NPM_CACHE_KEY }}
@@ -162,15 +163,15 @@ jobs:
           enableCrossOsArchive: true
 
       # TODO:  If the project contains internal npm packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   if: steps.has-cache.outputs.cache-hit == 'false'
+      # - name: Authenticate with GitHub Packages if cache does not exist
+      #   if: steps.has-cache.outputs.cache-hit != 'true'
       #   uses: im-open/authenticate-with-gh-package-registries@v1.0
       #   with:
       #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
       #     orgs: ''
 
-      - name: NPM Install
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: NPM Install if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true'
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           echo "Installing NPM"

--- a/workflow-templates/im-test-k6-operator.yml
+++ b/workflow-templates/im-test-k6-operator.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyAligator_v26   DO NOT REMOVE
+# Workflow Code: ZestyAligator_v27   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -148,10 +148,12 @@ jobs:
 
       - name: Check for an npm cache
         id: has-cache
-        uses: im-open/check-for-cache@v1.1.2
+        uses: actions/cache@v3.2.6
         with:
           path: '**/k6/node_modules'
           key: ${{ env.NPM_CACHE_KEY }}
+          lookup-only: true
+          enableCrossOsArchive: true
 
       # The remaining steps will only be executed if the cache was not found, otherwise they will be skipped.
 
@@ -159,14 +161,14 @@ jobs:
       # completes successfully.  Subsequent jobs and workflow runs can use this cached version of the node_modules
       # folder if the package-lock.json hasn't changed and it uses a im-linux runner to restore the cache from.
       # TODO: Delete if you don't build your k6 tests
-      - name: Install Node ${{ env.NODE_VERSION }}
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: Install Node ${{ env.NODE_VERSION }} if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup caching for node_modules directory
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: Setup caching for node_modules directory if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true
         uses: actions/cache@v3.2.6
         with:
           key: ${{ env.NPM_CACHE_KEY }}
@@ -174,15 +176,15 @@ jobs:
           enableCrossOsArchive: true
 
       # TODO:  If the project contains internal npm packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   if: steps.has-cache.outputs.cache-hit == 'false'
+      # - name: Authenticate with GitHub Packages if cache does not exist
+      #   if: steps.has-cache.outputs.cache-hit != 'true
       #   uses: im-open/authenticate-with-gh-package-registries@v1.0
       #   with:
       #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
       #     orgs: ''
 
-      - name: NPM Install
-        if: steps.has-cache.outputs.cache-hit == 'false'
+      - name: NPM Install if cache does not exist
+        if: steps.has-cache.outputs.cache-hit != 'true
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           echo "Installing NPM"


### PR DESCRIPTION
- The official actions/cache action now supports a lookup-only arg.  Replace the check-for-cache with actions/cache.  
- Take the opportunity to make it cross-platform as well.
- Change the conditions.  The actions/cache action only has an output if the cache-hit is true.  If the cache-hit is false there are no outputs.  This is weird in my opinion but it means the condition needs to change.
