### PR TITLE
PLPT-564 Use zip-upload-artifact composite action instead of upload-artifact

### DIFF
--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v47    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v48    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -340,19 +340,12 @@ jobs:
           line-threshold: 0
           branch-threshold: 0
 
-      - name: Pre-Zip Code Coverage Artifacts
-        # GitHub zips whatever we upload but they charge based on the pre-zip size.  
-        # The artifact will be double-zipped when downloaded but we will save on storage costs.
+      - name: zip and upload dotnet code coverage report
         if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        shell: pwsh
-        run: Compress-Archive -Path ./${{ env.CODE_COVERAGE_DIR_DOTNET }}/* -DestinationPath "./${{ env.CODE_COVERAGE_DIR_DOTNET }}/${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}.zip"
-        
-      - name: upload dotnet code coverage report
-        if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: actions/upload-artifact@v3
+        uses: im-open/zip-upload-artifact@v1.1.5
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}
-          path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}/${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}.zip
+          path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}
           retention-days: 15 # Cannot exceed 30 days.
 
   # TODO: Remove this job if you do not have jest tests
@@ -458,19 +451,12 @@ jobs:
           line-threshold: 0
           branch-threshold: 0
 
-      - name: Pre-Zip Code Coverage Artifacts
-        # GitHub zips whatever we upload but they charge based on the pre-zip size.  
-        # The artifact will be double-zipped when downloaded but we will save on storage costs.
+      - name: zip and upload jest code coverage report
         if: always() && steps.jest_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        shell: pwsh
-        run: Compress-Archive -Path ./${{ env.CODE_COVERAGE_DIR_JEST }}/* -DestinationPath "./${{ env.CODE_COVERAGE_DIR_JEST }}/${{ env.CODE_COVERAGE_REPORT_NAME_JEST }}.zip"
-        
-      - name: upload jest code coverage report
-        if: always() && steps.jest_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: actions/upload-artifact@v3
+        uses: im-open/zip-upload-artifact@v1.1.5
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_JEST }}
-          path: ${{ env.CODE_COVERAGE_DIR_JEST }}/${{ env.CODE_COVERAGE_REPORT_NAME_JEST }}.zip
+          path: ${{ env.CODE_COVERAGE_DIR_JEST }}
           retention-days: 15 # Cannot exceed 30 days.
 
   build-deployment-artifacts:

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -161,19 +161,12 @@ jobs:
           line-threshold: 0
           branch-threshold: 0
 
-      - name: Pre-Zip Code Coverage Artifacts
-        # GitHub zips whatever we upload but they charge based on the pre-zip size.  
-        # The artifact will be double-zipped when downloaded but we will save on storage costs.
+      - name: zip and upload dotnet code coverage report
         if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        shell: pwsh
-        run: Compress-Archive -Path ./${{ env.CODE_COVERAGE_DIR_DOTNET }}/* -DestinationPath "./${{ env.CODE_COVERAGE_DIR_DOTNET }}/${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}.zip"
-
-      - name: upload dotnet code coverage report
-        if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: actions/upload-artifact@v3
+        uses: im-open/zip-upload-artifact@v1.1.5
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}
-          path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}/${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}.zip
+          path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}
           retention-days: 15 # Cannot exceed 30 days.
 
       - name: Check for Test Failures

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v38    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v39    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package


### PR DESCRIPTION
In order to make it easier for teams to zip before uploading a composite action was created in im-open called [zip-upload-artifact](https://github.com/im-open/zip-upload-artifact). It takes the same inputs as [upload-artifact](https://github.com/actions/upload-artifact) so making the switch is as easy as changing the `uses` string.

For usage examples see workflows in:
- [account-management](https://github.com/im-enrollment/account-management/pull/1513)
- [agent-management](https://github.com/im-customer-engagement/agent-management/pull/1745)
- [frontend-tooling-bff](https://github.com/im-enrollment/frontend-tooling-bff/pull/803)
- [github-governance](https://github.com/im-platform/github-governance/blob/main/.github/workflows/github-code-search.yml#L48)
- [household-management](https://github.com/im-client/household-management/pull/1629)
