### PR TITLE
ARCH-2007 - Update the way outputs are set in pwsh

### DIFF
--- a/workflow-templates/im-build-db-ci.yml
+++ b/workflow-templates/im-build-db-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GiddyBuzzard_v17    DO NOT REMOVE
+# Workflow Code: GiddyBuzzard_v18    DO NOT REMOVE
 # Purpose:
 #    The main purpose of this workflow is to verify that the database can be created, all of the migration scripts can be run, and any tests that exist pass.
 #    In addition to that, however, there are three other things this workflow template is set up to do.
@@ -70,18 +70,19 @@ jobs:
           $CurrentBranchIsDefault = ($CurrentBranch -eq "${{ env.DEFAULT_BRANCH }}")
           $LastCommitIsSnapshot = ($LastCommitBy -eq "github-actions")
 
-          echo "isDefaultBranch=$CurrentBranchIsDefault" >> $GITHUB_OUTPUT
-          echo "isSnapshot=$LastCommitIsSnapshot" >> $GITHUB_OUTPUT
+          "isDefaultBranch=$CurrentBranchIsDefault" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "isSnapshot=$LastCommitIsSnapshot" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
 
           if ($LastCommitIsSnapshot -and !$CurrentBranchIsDefault)
           {
             Write-Host "Snapshot was last commit, skipping the other jobs"
-            echo "skip=true" >> $GITHUB_OUTPUT
+            "skip=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
           else
           {
             Write-Host "Snapshot was not the last commit, continuing with the other jobs"
-            echo "skip=false" >> $GITHUB_OUTPUT
+            "skip=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
   # TODO: Remove this linting job if your project doesn't need/want it
@@ -98,7 +99,8 @@ jobs:
 
       - id: migration-folder
         shell: pwsh
-        run: echo "folder=$($(Get-Date).Year).$($(Get-Date).Month.ToString("00"))" >> $GITHUB_OUTPUT
+        run: |
+          "folder=$($(Get-Date).Year).$($(Get-Date).Month.ToString("00"))" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       - name: SQL Lint
         uses: im-open/tsql-lint-action@v1.1
         with:
@@ -195,7 +197,7 @@ jobs:
       #     $mappedObjects = $changedObjects | foreach-object { @{ schemaName=$_.schemaName; objectName=$_.objectName; objectType=$_.objectType; operationType=$_.operationType } }
       #     $objectsAsJson = $mappedObjects | ConvertTo-Json -Compress
 
-      #     echo "json=$objectsAsJson" >> $GITHUB_OUTPUT
+      #     "json=$objectsAsJson" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       # - name: Increment snapshots
       #   uses: im-open/increment-database-object-snapshots@v1.0

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v45    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v46    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -267,7 +267,7 @@ jobs:
           az storage blob upload --no-progress --auth-mode login --account-name ${{ needs.set-vars.outputs.STORAGE_ACCOUNT }} --container-name ${{ env.PLAN_STORAGE_CONTAINER }} --file $terraformPlanName --name $terraformBlobName
           echo "The plan was successfully uploaded"
 
-          echo "tf_plan_name=$terraformPlanName" >> $env:GITHUB_OUTPUT
+          "tf_plan_name=$terraformPlanName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Azure logout
         run: |

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v23    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v24   DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -246,7 +246,7 @@ jobs:
           az storage blob upload --no-progress --auth-mode login --account-name ${{ needs.set-vars.outputs.STORAGE_ACCOUNT }} --container-name ${{ env.PLAN_STORAGE_CONTAINER }} --file $terraformPlanName --name $terraformBlobName
           echo "The plan was successfully uploaded"
 
-          echo "tf_plan_name=$terraformPlanName" >> $env:GITHUB_OUTPUT
+          "tf_plan_name=$terraformPlanName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Azure logout
         run: |


### PR DESCRIPTION
There was an issue in 1up-infrastructure when it tried to download a blob because the plan name output it was using was empty. 
 In the plan job, the plan blob name was being set in pwsh with an echo statement.  When I changed that echo statement to the pwsh syntax the plan name output was populated and the apply job was able to download the plan blob.

There wasn't an issue using the echo statements with pwsh to set outputs before but GitHub may have made a change (or maybe our self-hosted runners changed) so that it no longer works.

```sh
echo "tf_plan_name=$terraformPlanName" >> $GITHUB_OUTPUT # No longer works
"tf_plan_name=$terraformPlanName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append # This syntax works
```