### PR TITLE
Remove Cleanup Deployment Board

### DIFF
--- a/start-project-template-inventory.json
+++ b/start-project-template-inventory.json
@@ -1,7 +1,5 @@
 {
-    "AllRepositories": [
-        "im-deploy-cleanup-automated-board.yml"
-    ],
+    "AllRepositories": [],
     "bff-with-react": {
         "coreTemplates": [ 
             { "name": "im-deploy-az-app-manually.yml", "canHaveMultiples": true}


### PR DESCRIPTION
We'll no longer be using the update-deployment-board and cleanup-deployment-board actions and won't need the dedicated clean up deployment board workflow