### PR TITLE
Use Upload-Artifact v4

### DIFF
--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v50    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v51    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -342,7 +342,7 @@ jobs:
 
       - name: zip and upload dotnet code coverage report
         if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: im-open/zip-upload-artifact@v1.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}
           path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}
@@ -453,7 +453,7 @@ jobs:
 
       - name: zip and upload jest code coverage report
         if: always() && steps.jest_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: im-open/zip-upload-artifact@v1.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_JEST }}
           path: ${{ env.CODE_COVERAGE_DIR_JEST }}

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v40    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v41    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -163,7 +163,7 @@ jobs:
 
       - name: zip and upload dotnet code coverage report
         if: always() && steps.dotnet_coverage_check.outcome == 'success' && env.IS_DEPENDABOT_PR == 'false'
-        uses: im-open/zip-upload-artifact@v1.1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CODE_COVERAGE_REPORT_NAME_DOTNET }}
           path: ${{ env.CODE_COVERAGE_DIR_DOTNET }}

--- a/workflow-templates/im-test-cypress.yml
+++ b/workflow-templates/im-test-cypress.yml
@@ -1,4 +1,4 @@
-# Workflow Code: SurprisedHedgehog_v19    DO NOT REMOVE
+# Workflow Code: SurprisedHedgehog_v20    DO NOT REMOVE
 # Purpose:
 #    Runs the Cypress script specified in the workflow when commits
 #    are pushed to the PR or when someone kicks it off manually.
@@ -140,14 +140,14 @@ jobs:
 
       - name: Upload cypress screenshots if there are test failures
         if: steps.cypress.outcome == 'failure'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Failed Cypress Test Screenshots
           path: ${{ env.JS_TEST_DIR }}/${{ env.CYPRESS_SCREENSHOTS }}/screenshots.zip
           retention-days: 15 # Cannot exceed 30 days.
 
       - name: Upload Cypress Results Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Cypress Results ${{ github.run_number }}
           path: |

--- a/workflow-templates/im-test-k6-operator-approval.yml
+++ b/workflow-templates/im-test-k6-operator-approval.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyCrocodile_v7   DO NOT REMOVE
+# Workflow Code: ZestyCrocodile_v8   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -360,7 +360,7 @@ jobs:
       - name: Upload K6 Deployment Yaml if Cancelled
         if: cancelled()
         continue-on-error: true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.start-k6-test.outputs.deploy-yaml-artifact }}-bk
           path: ${{ env.WORKING_DIRECTORY }}/${{ steps.start-k6-test.outputs.run-name }}.yaml

--- a/workflow-templates/im-test-k6-operator.yml
+++ b/workflow-templates/im-test-k6-operator.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ZestyAligator_v28   DO NOT REMOVE
+# Workflow Code: ZestyAligator_v29   DO NOT REMOVE
 # Purpose:
 #    Runs K6 tests at scale in Azure Kubernetes.
 #    With the workflow the user specifies when they kick it off manually.
@@ -355,7 +355,7 @@ jobs:
       - name: Upload K6 Deployment Yaml if Cancelled
         if: cancelled()
         continue-on-error: true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.run-k6-operator-test.outputs.deploy-yaml-artifact }}-bk
           path: ${{ env.WORKING_DIRECTORY }}/${{ steps.run-k6-operator-test.outputs.run-name }}.yaml


### PR DESCRIPTION
The Purple Team has created [PLPT-697](https://jira.extendhealth.com/browse/PLPT-697) to update workflows that upload artifacts using v4.

Replacements Made:
- Changed usages of `zip-upload-artifact` to use `upload-artifact@v4`
- Updates usages of `upload-artifact` to use `v4`