### PR TITLE
ARCH-2011 - Updating for node20 versions & other updates

### DIFF
--- a/.github/workflows/im-reusable-finish-build-workflow.yml
+++ b/.github/workflows/im-reusable-finish-build-workflow.yml
@@ -85,40 +85,50 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
 
     steps:
-      - name: Check and print inputs
+      - name: Check for missing inputs
         uses: actions/github-script@v7
         with:
           script: |
-            // Some teams have this as a secret and some as a var, allow both ways
-            // but check at least one is provided
+            // Some teams have these as a secret and some as a var, allow both ways but check at least one is present
             const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
             if (!teamsUri || teamsUri.trim().length === 0){
               core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
             }
 
-            core.info('Reusable workflow inputs:');
-            const inputs = [
-              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
-              { name: 'next-version', value: '${{ inputs.next-version }}'},
-              { name: 'title-of-teams-post', value: '${{ inputs.title-of-teams-post }}'},
-              { name: 'is-merge-to-main', value: '${{ inputs.is-merge-to-main }}'},
-              { name: 'timezone', value: '${{ inputs.timezone }}'},
-              { name: 'additional-conclusions', value: '${{ inputs.additional-conclusions }}'},
-              { name: 'additional-pr-comment-content', value: '${{ inputs.additional-pr-comment-content }}'},
-              { name: 'custom-facts-for-team-channel', value: '${{ inputs.custom-facts-for-team-channel }}'},
-              { name: 'ms-teams-uri', value: '${{ inputs.ms-teams-uri }}'}
-            ];
-            for (const input of inputs){
-              console.log(`\n\t${input.name}: '${input.value}'`);
+      - name: Print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function printInput(inputName, inputValue, isMultilineInput){
+               if (!inputValue || inputValue.trim().length === 0){
+                core.info(`${inputName}: Not Provided`);
+              } else if (isMultilineInput){
+                console.log(`\n${inputName}:\n${inputValue}`);
+              }
+              else {
+                core.info(`${inputName}: ${inputValue}`);
+              }
             }
 
-            core.info('\n\nReusable workflow secrets:');
-            const secrets = [
-              { name: 'MS_TEAMS_URI', value: '${{ secrets.MS_TEAMS_URI }}'}
-            ];
-            for (const secret of secrets){
-              console.log(`\n\t${secret.name}: '${secret.value}'`);
-            }
+            core.startGroup('Reusable workflow inputs');
+            printInput('runs-on', '${{ inputs.runs-on }}');
+            printInput('next-version', '${{ inputs.next-version }}');
+            printInput('title-of-teams-post', '${{ inputs.title-of-teams-post }}');
+            printInput('is-merge-to-main', '${{ inputs.is-merge-to-main }}');
+            printInput('timezone', '${{ inputs.timezone }}');
+            printInput('ms-teams-uri', '${{ inputs.ms-teams-uri }}');
+            printInput('custom-facts-for-team-channel', process.env.FACTS, true);
+            printInput('additional-pr-comment-content', process.env.ADDITIONAL_CONTENT, true);
+            printInput('additional-conclusions', process.env.ADDITIONAL_CONCLUSIONS, true);
+            core.endGroup();
+
+            core.startGroup('Reusable workflow secrets');
+            printInput('MS_TEAMS_URI', '${{ secrets.MS_TEAMS_URI }}');
+            core.endGroup();
+        env:
+          FACTS: ${{ inputs.custom-facts-for-team-channel }}
+          ADDITIONAL_CONTENT: ${{ inputs.additional-pr-comment-content }}
+          ADDITIONAL_CONCLUSIONS: ${{ inputs.additional-conclusions }}
 
       - uses: im-open/workflow-conclusion@v2.2
         id: conclusion

--- a/.github/workflows/im-reusable-finish-build-workflow.yml
+++ b/.github/workflows/im-reusable-finish-build-workflow.yml
@@ -1,5 +1,5 @@
 # The purpose of this reusable job is to run the final steps of a CI build workflow
-# which includes posting a status to teams, updating a PR comment and setting the final 
+# which includes posting a status to teams, updating a PR comment and setting the final
 # workflow outcome.
 
 # Example Usage in a repo's workflow:
@@ -29,6 +29,7 @@
 #          { "name": "Actor", "value": "${{ github.actor }}" },
 #          { "name": "Version", "value": "${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}" }
 #        ]
+#      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}  # Use this input (preferred) or the secret
 
 on:
   workflow_call:
@@ -48,39 +49,77 @@ on:
         required: true
         type: string
       is-merge-to-main:
-          description: Flag indicating whether this is a merge to the default branch. Expected `true` or `false`.
-          required: true
-          type: string
+        description: Flag indicating whether this is a merge to the default branch. Expected `true` or `false`.
+        required: true
+        type: string
       timezone:
         description: 'Timezone for the project.  Defaults to america/denver.'
         required: false
         type: string
         default: 'america/denver'
       additional-conclusions:
-          description: Valid JSON array of additional conclusion items that should be used to determine if the workflow succeeded or failed
-          required: false
-          type: string
-          default: ''
+        description: Valid JSON array of additional conclusion items that should be used to determine if the workflow succeeded or failed
+        required: false
+        type: string
+        default: ''
       additional-pr-comment-content:
-        description: Additional PR comment content aside from workflow run and next version. 
+        description: Additional PR comment content aside from workflow run and next version.
         required: false
         type: string
       custom-facts-for-team-channel:
         description: The custom facts that will be included in the post in the team's channel.  By default Workflow, Run, Actor and Version are included.
         required: false
-        type: string  
-  
+        type: string
+      ms-teams-uri:
+        description: The URI for the teams channel where a status will be posted.  Either this value or the secret MS_TEAMS_URI must be provided.  This input is the preferred way to provide the URI but the secret should be used instead if the value is defined as a secret.
+        required: false
+        type: string
+
     secrets:
       MS_TEAMS_URI:
-        description: The URI for the teams channel where a status will be posted.
-        required: true
-      
+        description: The URI for the teams channel where a status will be posted.  Either this value or the input ms-teams-uri must be provided.  The input is the preferred way to provide the URI but the secret should be used if the value is defined as a secret.
+        required: false
 
 jobs:
   finish-build:
     runs-on: ${{ inputs.runs-on }}
-    
+
     steps:
+      - name: Check and print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Some teams have this as a secret and some as a var, allow both ways
+            // but check at least one is provided
+            const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
+            if (!teamsUri || teamsUri.trim().length === 0){
+              core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
+            }
+
+            core.info('Reusable workflow inputs:');
+            const inputs = [
+              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
+              { name: 'next-version', value: '${{ inputs.next-version }}'},
+              { name: 'title-of-teams-post', value: '${{ inputs.title-of-teams-post }}'},
+              { name: 'is-merge-to-main', value: '${{ inputs.is-merge-to-main }}'},
+              { name: 'timezone', value: '${{ inputs.timezone }}'},
+              { name: 'additional-conclusions', value: '${{ inputs.additional-conclusions }}'},
+              { name: 'additional-pr-comment-content', value: '${{ inputs.additional-pr-comment-content }}'},
+              { name: 'custom-facts-for-team-channel', value: '${{ inputs.custom-facts-for-team-channel }}'},
+              { name: 'ms-teams-uri', value: '${{ inputs.ms-teams-uri }}'}
+            ];
+            for (const input of inputs){
+              console.log(`\n\t${input.name}: '${input.value}'`);
+            }
+
+            core.info('\n\nReusable workflow secrets:');
+            const secrets = [
+              { name: 'MS_TEAMS_URI', value: '${{ secrets.MS_TEAMS_URI }}'}
+            ];
+            for (const secret of secrets){
+              console.log(`\n\t${secret.name}: '${secret.value}'`);
+            }
+
       - uses: im-open/workflow-conclusion@v2.2
         id: conclusion
         with:
@@ -90,13 +129,13 @@ jobs:
       - name: Configure facts for team's notification channel
         if: always()
         id: team-channel-facts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const rawFacts = process.env.FACTS;
             console.log(`"${rawFacts}"`);
             let facts = rawFacts && rawFacts.trim().length > 0 ? JSON.parse(rawFacts) : null;
-            
+
             if (!facts || facts.length === 0){
               console.log(`Custom facts were not provided for the Team's Notification channel, use the default facts:`);
               facts = [
@@ -123,13 +162,13 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Build
-          teams-uri: ${{ secrets.MS_TEAMS_URI }}
+          teams-uri: ${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}
           timezone: ${{ inputs.timezone }}
           custom-facts: ${{ steps.team-channel-facts.outputs.facts }}
-      
+
       - name: Construct PR Comment
         id: comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const isMergeToMain = '${{ inputs.is-merge-to-main }}' == 'true';
@@ -139,11 +178,11 @@ jobs:
             const runId = '${{ github.run_id }}';
 
             const workflowRunText = `[Workflow Run - ${conclusion}](https://github.com/${orgAndRepo}/actions/runs/${runId})`;
-            
+
             const nextVersionText = isMergeToMain ?
               `[Tag - ${nextVersion}](https://github.com/${orgAndRepo}/releases/tag/${nextVersion})` :
               `Next Version - ${nextVersion}`;
-            
+
             const prComment = `
             - ${workflowRunText}
             - ${nextVersionText}

--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -140,12 +140,11 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.gh-secrets-environment }}
     steps:
-      - name: Check and print inputs
+      - name: Check for missing inputs
         uses: actions/github-script@v7
         with:
           script: |
-            // Some teams have this as a secret and some as a var, allow both ways
-            // but check at least one is provided
+            // Some teams have these as a secret and some as a var, allow both ways but check at least one is present
             const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
             if (!teamsUri || teamsUri.trim().length === 0){
               core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
@@ -155,40 +154,49 @@ jobs:
               core.setFailed('The DEPLOY_NOTIFICATIONS_CHANNEL secret or the deploy-notifications-channel input (preferred) must be provided.');
             }
 
-            core.info('Reusable workflow inputs:');
-            const inputs = [
-              { name: 'deployment-environment', value: '${{ inputs.deployment-environment }}'},
-              { name: 'gh-secrets-environment', value: '${{ inputs.gh-secrets-environment }}'},
-              { name: 'release-tag', value: '${{ inputs.release-tag }}'},
-              { name: 'title-of-teams-post', value: '${{ inputs.title-of-teams-post }}'},
-              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
-              { name: 'post-status-in-deployment-notifications-channel', value: '${{ inputs.post-status-in-deployment-notifications-channel }}'},
-              { name: 'timezone', value: '${{ inputs.timezone }}'},
-              { name: 'deployment-board-number', value: '${{ inputs.deployment-board-number }}'},
-              { name: 'deployable-type', value: '${{ inputs.deployable-type }}'},
-              { name: 'deployable-label', value: '${{ inputs.deployable-label }}'},
-              { name: 'enable-deployment-slot-tracking', value: '${{ inputs.enable-deployment-slot-tracking }}'},
-              { name: 'slot-swapped-with-production-slot', value: '${{ inputs.slot-swapped-with-production-slot }}'},
-              { name: 'target-slot', value: '${{ inputs.target-slot }}'},
-              { name: 'source-slot', value: '${{ inputs.source-slot }}'},
-              { name: 'instance', value: '${{ inputs.instance }}'},
-              { name: 'custom-facts-for-team-channel', value: '${{ inputs.custom-facts-for-team-channel }}'},
-              { name: 'custom-facts-for-deployment-notifications-channel', value: '${{ inputs.custom-facts-for-deployment-notifications-channel }}'},
-              { name: 'ms-teams-uri', value: '${{ inputs.ms-teams-uri }}'},
-              { name: 'deploy-notifications-channel', value: '${{ inputs.deploy-notifications-channel }}'}
-            ];
-            for (const input of inputs){
-              console.log(`\n\t${input.name}: '${input.value}'`);
+      - name: Print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function printInput(inputName, inputValue, isMultilineInput){
+               if (!inputValue || inputValue.trim().length === 0){
+                core.info(`${inputName}: Not Provided`);
+              } else if (isMultilineInput){
+                console.log(`\n${inputName}:\n${inputValue}`);
+              }
+              else {
+                core.info(`${inputName}: ${inputValue}`);
+              }
             }
+            core.startGroup('Reusable workflow inputs');
+            printInput('deployment-environment', '${{ inputs.deployment-environment }}');
+            printInput('gh-secrets-environment', '${{ inputs.gh-secrets-environment }}');
+            printInput('release-tag', '${{ inputs.release-tag }}');
+            printInput('title-of-teams-post', '${{ inputs.title-of-teams-post }}');
+            printInput('runs-on', '${{ inputs.runs-on }}');
+            printInput('post-status-in-deployment-notifications-channel', '${{ inputs.post-status-in-deployment-notifications-channel }}');
+            printInput('timezone', '${{ inputs.timezone }}');
+            printInput('deployment-board-number', '${{ inputs.deployment-board-number }}');
+            printInput('deployable-type', '${{ inputs.deployable-type }}');
+            printInput('deployable-label', '${{ inputs.deployable-label }}');
+            printInput('enable-deployment-slot-tracking', '${{ inputs.enable-deployment-slot-tracking }}');
+            printInput('slot-swapped-with-production-slot', '${{ inputs.slot-swapped-with-production-slot }}');
+            printInput('target-slot', '${{ inputs.target-slot }}');
+            printInput('source-slot', '${{ inputs.source-slot }}');
+            printInput('instance', '${{ inputs.instance }}');
+            printInput('ms-teams-uri', '${{ inputs.ms-teams-uri }}');
+            printInput('deploy-notifications-channel', '${{ inputs.deploy-notifications-channel }}');
+            printInput('custom-facts-for-team-channel', process.env.CUSTOM_FACTS_TEAMS, true);
+            printInput('custom-facts-for-deployment-notifications-channel', process.env.CUSTOM_FACTS_DEPLOY, true);
+            core.endGroup();
 
-            core.info('\n\nReusable workflow secrets:');
-            const secrets = [
-              { name: 'MS_TEAMS_URI', value: '${{ secrets.MS_TEAMS_URI }}'},
-              { name: 'DEPLOY_NOTIFICATIONS_CHANNEL', value: '${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}'}
-            ];
-            for (const secret of secrets){
-              console.log(`\n\t${secret.name}: '${secret.value}'`);
-            }
+            core.startGroup('Reusable workflow secrets');
+            printInput('MS_TEAMS_URI', '${{ secrets.MS_TEAMS_URI }}');
+            printInput('DEPLOY_NOTIFICATIONS_CHANNEL', '${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}');
+            core.endGroup();
+        env:
+          CUSTOM_FACTS_TEAMS: ${{ inputs.custom-facts-for-team-channel }}
+          CUSTOM_FACTS_DEPLOY: ${{ inputs.custom-facts-for-deployment-notifications-channel }}
 
       - uses: im-open/workflow-conclusion@v2.2
         id: conclusion

--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -27,9 +27,8 @@
 #        { "name": "Actor", "value": "${{ github.actor }}" },
 #        { "name": "Version", "value": "${{ inputs.tag }}" }
 #      ]
-#    secrets:
-#      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-#      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL}}
+#      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}  # Use this input (preferred) or the secret
+#      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}  # The input is the preferred way to provide the URI.  The secret is deprecated.
 
 on:
   workflow_call:
@@ -83,7 +82,7 @@ on:
         type: string
         default: null
       entity:
-        description: 'The catalog-info.yml metadata.name value for mapping in Tech Hub.'
+        description: 'The catalog-info.yml metadata.name value for mapping in TechHub.'
         required: false
         type: string
         default: null
@@ -120,19 +119,77 @@ on:
         description: 'The custom facts that will be included in the Deployment Notifications channel.  By default Actor and Version are included.'
         required: false
         type: string
+      ms-teams-uri:
+        description: The URI for the teams channel where a status will be posted.  Either this value or the secret MS_TEAMS_URI must be provided.  This input is the preferred way to provide the URI but the secret should be used instead if the value is defined as a secret.
+        required: false
+        type: string
+      deploy-notifications-channel:
+        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the secret DEPLOY_NOTIFICATIONS_CHANNEL must be provided.  This secret is deprecated because this value is defined as a variable at the org level.'
+        required: false
+        type: string
     secrets:
       MS_TEAMS_URI:
-        description: 'The URI for the teams channel where a status will be posted.'
-        required: true
+        description: 'The URI for the teams channel where a status will be posted.  Either this value or the input ms-teams-uri must be provided.  The input is the preferred way to provide the URI but the secret should be used if the value is defined as a secret.'
+        required: false
       DEPLOY_NOTIFICATIONS_CHANNEL:
-        description: 'The URI for the teams channel where a status will be posted.'
-        required: true
+        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the input deploy-notifications-channel must be provided.  This secret is deprecated because this value is defined as a variable at the org level.  Please switch to using the input.'
+        required: false
 
 jobs:
   finish-deployment-workflow:
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.gh-secrets-environment }}
     steps:
+      - name: Check and print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Some teams have this as a secret and some as a var, allow both ways
+            // but check at least one is provided
+            const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
+            if (!teamsUri || teamsUri.trim().length === 0){
+              core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
+            }
+            const notificationsUri = '${{ inputs.deploy-notifications-channel || secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}';
+            if (!notificationsUri || notificationsUri.trim().length === 0){
+              core.setFailed('The DEPLOY_NOTIFICATIONS_CHANNEL secret or the deploy-notifications-channel input (preferred) must be provided.');
+            }
+
+            core.info('Reusable workflow inputs:');
+            const inputs = [
+              { name: 'deployment-environment', value: '${{ inputs.deployment-environment }}'},
+              { name: 'gh-secrets-environment', value: '${{ inputs.gh-secrets-environment }}'},
+              { name: 'release-tag', value: '${{ inputs.release-tag }}'},
+              { name: 'title-of-teams-post', value: '${{ inputs.title-of-teams-post }}'},
+              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
+              { name: 'post-status-in-deployment-notifications-channel', value: '${{ inputs.post-status-in-deployment-notifications-channel }}'},
+              { name: 'timezone', value: '${{ inputs.timezone }}'},
+              { name: 'deployment-board-number', value: '${{ inputs.deployment-board-number }}'},
+              { name: 'deployable-type', value: '${{ inputs.deployable-type }}'},
+              { name: 'deployable-label', value: '${{ inputs.deployable-label }}'},
+              { name: 'enable-deployment-slot-tracking', value: '${{ inputs.enable-deployment-slot-tracking }}'},
+              { name: 'slot-swapped-with-production-slot', value: '${{ inputs.slot-swapped-with-production-slot }}'},
+              { name: 'target-slot', value: '${{ inputs.target-slot }}'},
+              { name: 'source-slot', value: '${{ inputs.source-slot }}'},
+              { name: 'instance', value: '${{ inputs.instance }}'},
+              { name: 'custom-facts-for-team-channel', value: '${{ inputs.custom-facts-for-team-channel }}'},
+              { name: 'custom-facts-for-deployment-notifications-channel', value: '${{ inputs.custom-facts-for-deployment-notifications-channel }}'},
+              { name: 'ms-teams-uri', value: '${{ inputs.ms-teams-uri }}'},
+              { name: 'deploy-notifications-channel', value: '${{ inputs.deploy-notifications-channel }}'}
+            ];
+            for (const input of inputs){
+              console.log(`\n\t${input.name}: '${input.value}'`);
+            }
+
+            core.info('\n\nReusable workflow secrets:');
+            const secrets = [
+              { name: 'MS_TEAMS_URI', value: '${{ secrets.MS_TEAMS_URI }}'},
+              { name: 'DEPLOY_NOTIFICATIONS_CHANNEL', value: '${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}'}
+            ];
+            for (const secret of secrets){
+              console.log(`\n\t${secret.name}: '${secret.value}'`);
+            }
+
       - uses: im-open/workflow-conclusion@v2.2
         id: conclusion
         with:
@@ -156,9 +213,9 @@ jobs:
           source-slot: ${{ inputs.source-slot }}
           timezone: ${{ inputs.timezone }}
 
-      # Only run this step if Tech Hub metadata.name value
+      # Only run this step if TechHub metadata.name value
       # and a metadata.instance value are provided
-      - name: Create GitHub Deployment
+      - name: Create GitHub Deployment for TechHub
         if: ${{ inputs.entity != null && (inputs.instance != null || inputs.target-slot != null) }}
         uses: im-open/create-github-deployment@v1.0
         with:
@@ -174,7 +231,7 @@ jobs:
       - name: Configure facts for team's notification channel
         if: always()
         id: team-channel-facts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const rawFacts = process.env.FACTS;
@@ -206,14 +263,14 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Deploy
-          teams-uri: ${{ secrets.MS_TEAMS_URI }}
+          teams-uri: ${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}
           timezone: ${{ inputs.timezone }}
           custom-facts: ${{ steps.team-channel-facts.outputs.facts }}
 
       - name: Determine if a post should be made in Deployment Notifications channel
         if: always()
         id: post-to-deployment-channel
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const postInProd = ${{ inputs.post-status-in-deployment-notifications-channel }};
@@ -240,7 +297,7 @@ jobs:
       - name: Configure facts for Deployment Notifications channel
         if: always() && steps.post-to-deployment-channel.outputs.post == 'true'
         id: deployment-channel-facts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const rawFacts = process.env.FACTS;
@@ -269,7 +326,7 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Deploy
-          teams-uri: ${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+          teams-uri: ${{ inputs.deploy-notifications-channel || secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
           timezone: ${{ inputs.timezone }}
           include-default-facts: false # This cuts down on the message size for the prod room
           custom-facts: ${{ steps.deployment-channel-facts.outputs.facts }}

--- a/.github/workflows/im-reusable-setup-build-workflow.yml
+++ b/.github/workflows/im-reusable-setup-build-workflow.yml
@@ -85,16 +85,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.info('Reusable workflow inputs:');
-            const inputs = [
-              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
-              { name: 'default-branch', value: '${{ inputs.default-branch }}'},
-              { name: 'tag-prefix', value: '${{ inputs.tag-prefix }}'},
-              { name: 'workflow-summary', value: '${{ inputs.workflow-summary }}'}
-            ];
-            for (const input of inputs){
-              console.log(`\n\t${input.name}: '${input.value}'`);
+            function printInput(inputName, inputValue, isMultilineInput){
+               if (!inputValue || inputValue.trim().length === 0){
+                core.info(`${inputName}: Not Provided`);
+              } else if (isMultilineInput){
+                console.log(`\n${inputName}:\n${inputValue}`);
+              }
+              else {
+                core.info(`${inputName}: ${inputValue}`);
+              }
             }
+            printInput('runs-on', '${{ inputs.runs-on }}');
+            printInput('default-branch', '${{ inputs.default-branch }}');
+            printInput('tag-prefix', '${{ inputs.tag-prefix }}');
+            printInput('workflow-summary', process.env.SUMMARY, true);
+        env:
+          SUMMARY: ${{ inputs.workflow-summary }}
 
       - name: Set default env variables
         id: set-vars

--- a/.github/workflows/im-reusable-setup-build-workflow.yml
+++ b/.github/workflows/im-reusable-setup-build-workflow.yml
@@ -81,9 +81,24 @@ jobs:
       NEXT_VERSION_NO_PREFIX: ${{ steps.version.outputs.NEXT_VERSION_NO_PREFIX }}
 
     steps:
+      - name: Print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.info('Reusable workflow inputs:');
+            const inputs = [
+              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
+              { name: 'default-branch', value: '${{ inputs.default-branch }}'},
+              { name: 'tag-prefix', value: '${{ inputs.tag-prefix }}'},
+              { name: 'workflow-summary', value: '${{ inputs.workflow-summary }}'}
+            ];
+            for (const input of inputs){
+              console.log(`\n\t${input.name}: '${input.value}'`);
+            }
+
       - name: Set default env variables
         id: set-vars
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const targetRef = '${{ github.base_ref }}';
@@ -119,7 +134,7 @@ jobs:
 
       - name: Check if Dependabot PR
         id: actor_check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const actor = '${{ github.actor}}';
@@ -133,7 +148,7 @@ jobs:
 
       - name: Construct Workflow Summary
         id: summary
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let summary = process.env.SUMMARY;
@@ -163,7 +178,7 @@ jobs:
 
       - run: echo '${{ steps.summary.outputs.summary }}' >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: steps.set-vars.outputs.CONTINUE_WORKFLOW == 'true'
         with:
           ref: ${{ steps.set-vars.outputs.REF_TO_BUILD_AND_TAG }}

--- a/.github/workflows/im-reusable-setup-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-setup-deployment-workflow.yml
@@ -3,7 +3,6 @@
 # (meaning it has been reviewed and merged into main) and that the release is production
 # ready (it is not a draft/pre-release).
 
-
 # Example Usage in a repo's workflow:
 # jobs:
 #  setup-deployment-workflow:
@@ -35,12 +34,12 @@ on:
         description: Comma separated list of production environments to check against.  Defaults to 'prod,prod-secondary'
         required: false
         type: string
-        default: 'prod,prod-secondary'      
+        default: 'prod,prod-secondary'
       verify-release-production-ready:
-          description: Verify associated release is not draft or prerelease
-          required: false
-          type: boolean
-          default: true
+        description: Verify associated release is not draft or prerelease
+        required: false
+        type: boolean
+        default: true
       default-branch:
         description: Default branch of the repository
         required: false
@@ -50,15 +49,33 @@ on:
         description: 'String that will override the default GitHub Summary when provided.'
         type: string
         required: false
-      
+
 jobs:
   setup-deployment-workflow:
     runs-on: ${{ inputs.runs-on}}
 
     steps:
+      - name: Print inputs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.info('Reusable workflow inputs:');
+            const inputs = [
+              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
+              { name: 'ref-to-deploy', value: '${{ inputs.ref-to-deploy }}'},
+              { name: 'deployment-environment', value: '${{ inputs.deployment-environment }}'},
+              { name: 'production-environments', value: '${{ inputs.production-environments }}'},
+              { name: 'verify-release-production-ready', value: '${{ inputs.verify-release-production-ready }}'},
+              { name: 'default-branch', value: '${{ inputs.default-branch }}'},
+              { name: 'workflow-summary', value: '${{ inputs.workflow-summary }}'}
+            ];
+            for (const input of inputs){
+              console.log(`\n\t${input.name}: '${input.value}'`);
+            }
+
       - name: Construct Workflow Summary
-        id: summary  
-        uses: actions/github-script@v6
+        id: summary
+        uses: actions/github-script@v7
         with:
           script: |
             let summary = process.env.SUMMARY;
@@ -79,18 +96,18 @@ jobs:
             core.setOutput('summary', summary);
         env:
           SUMMARY: ${{ inputs.workflow-summary }}
-      
+
       - run: echo '${{ steps.summary.outputs.summary }}' >> $GITHUB_STEP_SUMMARY
 
-      # In this job, always checkout the default branch (not the tag that was provided as an input).  
-      # Also use fetch-depth: 0 to retrieve the history and tags so we can check if a tag is 
+      # In this job, always checkout the default branch (not the tag that was provided as an input).
+      # Also use fetch-depth: 0 to retrieve the history and tags so we can check if a tag is
       # exists, is reachable from the default branch and is production ready.
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.default-branch }}
           fetch-depth: 0
-      
+
       - name: Verify Tag Exists
         uses: im-open/verify-git-ref@v1.2
         with:
@@ -98,7 +115,7 @@ jobs:
 
       - name: Determine if deployment is to Prod
         id: check-env
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const prodEnvsRaw = '${{ inputs.production-environments }}';
@@ -108,7 +125,7 @@ jobs:
             }
             const prodEnvs = prodEnvsRaw.split(',').map(e => e.trim());
             const deploymentEnv = '${{ inputs.deployment-environment }}'.trim();
-            
+
             const isProd = prodEnvs.includes(deploymentEnv);
             core.setOutput('IS_PROD', isProd);
 
@@ -117,7 +134,7 @@ jobs:
         with:
           tag: ${{ inputs.ref-to-deploy }}
           default-branch: ${{ inputs.default-branch }}
-          error-if-not-reachable: true  # This only runs for prod environments, so if the tag is not in main, it should fail
+          error-if-not-reachable: true # This only runs for prod environments, so if the tag is not in main, it should fail
 
       - uses: im-open/is-release-production-ready@v1
         if: steps.check-env.outputs.IS_PROD == 'true' && inputs.verify-release-production-ready == 'true'

--- a/.github/workflows/im-reusable-setup-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-setup-deployment-workflow.yml
@@ -59,19 +59,26 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.info('Reusable workflow inputs:');
-            const inputs = [
-              { name: 'runs-on', value: '${{ inputs.runs-on }}'},
-              { name: 'ref-to-deploy', value: '${{ inputs.ref-to-deploy }}'},
-              { name: 'deployment-environment', value: '${{ inputs.deployment-environment }}'},
-              { name: 'production-environments', value: '${{ inputs.production-environments }}'},
-              { name: 'verify-release-production-ready', value: '${{ inputs.verify-release-production-ready }}'},
-              { name: 'default-branch', value: '${{ inputs.default-branch }}'},
-              { name: 'workflow-summary', value: '${{ inputs.workflow-summary }}'}
-            ];
-            for (const input of inputs){
-              console.log(`\n\t${input.name}: '${input.value}'`);
+            function printInput(inputName, inputValue, isMultilineInput){
+               if (!inputValue || inputValue.trim().length === 0){
+                core.info(`${inputName}: Not Provided`);
+              } else if (isMultilineInput){
+                console.log(`\n${inputName}:\n${inputValue}`);
+              }
+              else {
+                core.info(`${inputName}: ${inputValue}`);
+              }
             }
+            printInput('runs-on', '${{ inputs.runs-on }}');
+            printInput('ref-to-deploy', '${{ inputs.ref-to-deploy }}');
+            printInput('deployment-environment', '${{ inputs.deployment-environment }}');
+            printInput('production-environments', '${{ inputs.production-environments }}');
+            printInput('verify-release-production-ready', '${{ inputs.verify-release-production-ready }}');
+            printInput('default-branch', '${{ inputs.default-branch }}');
+            printInput('workflow-summary', process.env.SUMMARY, true);
+            
+        env:
+          SUMMARY: ${{ inputs.workflow-summary }}
 
       - name: Construct Workflow Summary
         id: summary

--- a/.github/workflows/increment-version-and-kick-off-sync.yml
+++ b/.github/workflows/increment-version-and-kick-off-sync.yml
@@ -31,7 +31,7 @@ jobs:
       # that may operate on PR controlled contents like in the case of npm install.
       # Here we are just checking it out to calculate the next version
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
           git push origin ${{ steps.version.outputs.NEXT_MINOR_VERSION }} -f
 
       - name: Tell github-management to sync templates
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           # You have to use something with write access to the repo. GITHUB_TOKEN
           # doesn't work because it doesn't have access to another repo.

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v51    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v52    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -613,6 +613,7 @@ jobs:
           { "name": "jest test", "conclusion" : "${{ needs.jest.outputs.test }}" },
           { "name": "jest coverage", "conclusion" : "${{ needs.jest.outputs.coverage }}" }
         ]
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       # additional-pr-comment-content: |  # TODO: Additional PR content can be added if desired.  Links for the workflow run and text for the next version/tag are included by default
       # timezone: 'america/denver'        # TODO: Include this argument and update if your timezone is not america/denver
       # custom-facts-for-team-channel: |  # TODO: These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
@@ -622,5 +623,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ needs.setup-build-workflow.outputs.NEXT_VERSION }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-build-npm-package.yml
+++ b/workflow-templates/im-build-npm-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GloomyBadger_v31    DO NOT REMOVE
+# Workflow Code: GloomyBadger_v32    DO NOT REMOVE
 # Purpose:
 #    Automatically calculates the next semantic version, runs an npm ci, an npm run tests
 #    if there is one, an npm publish and then pushes a latest tag for main builds. When the
@@ -147,6 +147,7 @@ jobs:
           ```bash
           npm install @<org>/<package-name>@${{ needs.build-and-publish-to-gpr.outputs.NEXT_VERSION }}
           ```
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       # timezone: 'america/denver'        # TODO: Include this argument and update if your timezone is not america/denver
       # custom-facts-for-team-channel: |  # TODO: These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       #   [
@@ -155,6 +156,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ needs.build-and-publish-to-gpr.outputs.NEXT_VERSION }}" }
       #   ]
-      
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v41    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v42    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -220,6 +220,7 @@ jobs:
       next-version: ${{ needs.setup-build-workflow.outputs.NEXT_VERSION }}
       title-of-teams-post: 'Build and Publish <project-name> to GH Packages' # TODO: Replace <project-name>
       is-merge-to-main: ${{ needs.setup-build-workflow.outputs.IS_MERGE_TO_MAIN }}
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       # timezone: 'america/denver'         # TODO: Include this argument and update if your timezone is not america/denver
       # additional-pr-comment-content: |   # TODO: Additional PR content can be added if desired.  Links for the workflow run and text for the next version/tag are included by default
       # custom-facts-for-team-channel: |   # TODO: These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
@@ -229,6 +230,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ needs.setup-build-workflow.outputs.NEXT_VERSION }}" }
       #   ]
-
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}

--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmbitiousLizard_v47    DO NOT REMOVE
+# Workflow Code: AmbitiousLizard_v48    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified
@@ -68,6 +68,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   RELEASE_TAG: ${{ inputs.tag }} # This is the tag that we'll be deploying
@@ -462,7 +467,9 @@ jobs:
       gh-secrets-environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT}} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag }}
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.AZ_APP_NAME }} ${{ inputs.tag }} to ${{ inputs.environment-or-target }}' # TODO:  Verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -484,6 +491,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v32    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v33    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -63,6 +63,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   RELEASE_TAG: ${{ inputs.tag == 0 && github.ref_name || inputs.tag }} # This is the tag that we'll be deploying
@@ -278,7 +283,9 @@ jobs:
       gh-secrets-environment: ${{ needs.set-vars.outputs.GITHUB_SECRETS_ENVIRONMENT }} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag == 0 && github.ref_name || inputs.tag }}
       title-of-teams-post: 'Deploy ${{ needs.deploy-az-db.outputs.DB_NAME }} ${{ inputs.tag == 0 && github.ref_name || inputs.tag }} to ${{ inputs.environment-or-target }}' # TODO:  Verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -300,6 +307,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag == 0 && github.ref_name || inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-files-to-az-storage-account.yml
+++ b/workflow-templates/im-deploy-files-to-az-storage-account.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BubblyGreyhound_v25    DO NOT REMOVE
+# Workflow Code: BubblyGreyhound_v26    DO NOT REMOVE
 # Purpose:
 #    Checks out the repository and deploys a directory to the
 #    specified storage account when someone kicks it off manually.
@@ -41,6 +41,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   ENVIRONMENT: ${{ github.event.inputs.environment }}
@@ -98,7 +103,7 @@ jobs:
             -d '${{ env.TARGET_CONTAINER }}' \
             -s '${{ env.SOURCE_DIRECTORY }}'
 
-      # Only run this step if Tech Hub metadata.name value is passed in
+      # Only run this step if TechHub metadata.name value is passed in
       - name: Create GitHub Deployment
         if: always()
         uses: im-open/create-github-deployment@v1.0

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FuzzyDragon_v45    DO NOT REMOVE
+# Workflow Code: FuzzyDragon_v46    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified environments,
@@ -70,6 +70,11 @@ on:
 permissions:
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   ENVIRONMENT: ${{ inputs.environment }}
@@ -402,7 +407,9 @@ jobs:
       gh-secrets-environment: ${{ inputs.environment}} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag }}
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.WEBSITE_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -424,6 +431,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v33    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v34    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -63,6 +63,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   ENVIRONMENT: ${{ inputs.environment }}
@@ -217,7 +222,9 @@ jobs:
       gh-secrets-environment: ${{ inputs.environment }} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag }}
       title-of-teams-post: 'Deploy ${{ needs.deploy-on-prem-db.outputs.DB_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -239,6 +246,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
+++ b/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritableEagle_v34    DO NOT REMOVE
+# Workflow Code: IrritableEagle_v35    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform apply -auto-approve with the changes
 #    in the PR against the dev environment when a PR is merged to main.
@@ -27,6 +27,11 @@ permissions:
   contents: read
   # Required create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 env:
   TIMEZONE: 'america/denver' # TODO: Verify timezone
   PAGERDUTY_WINDOW_IN_MIN: 10 # TODO: Verify the length of your PD Maintenance Window
@@ -136,7 +141,7 @@ jobs:
               { "name": "Actor", "value": "${{ github.actor }}" }
             ]
 
-        # Only run this step if Tech Hub metadata.name value is passed in
+        # Only run this step if TechHub metadata.name value is passed in
       - name: Create GitHub Deployment
         if: always()
         uses: im-open/create-github-deployment@v1.0

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v46    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v47    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -41,6 +41,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   DEPLOYMENT_DESC: 'Applying <project-name> ${{ inputs.root-module }} terraform at ${{ inputs.branch-tag-sha }} from GitHub Actions.' # TODO: Replace <project-name> with your project
@@ -415,7 +420,9 @@ jobs:
       release-tag: ${{ inputs.branch-tag-sha }}
       title-of-teams-post: 'Deploy <<PROJECT_NAME>> @${{ inputs.branch-tag-sha }} to ${{ inputs.root-module }}' # TODO:  Replace <<PROJECT_NAME>> and verify title to ensure it is descriptive/readable.
       post-status-in-deployment-notifications-channel: false
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -436,6 +443,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.branch-tag-sha  }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MysteriousStranger_v16    DO NOT REMOVE
+# Workflow Code: MysteriousStranger_v17    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -66,6 +66,11 @@ on:
 permissions:
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   ENVIRONMENT: ${{ inputs.environment }}
@@ -227,7 +232,9 @@ jobs:
       gh-secrets-environment: ${{ inputs.environment }} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag }}
       title-of-teams-post: 'Deploy <<PROJECT NAME>> files @${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Replace <<PROJECT_NAME>> and verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -249,6 +256,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MaterialVolcano_v39    DO NOT REMOVE
+# Workflow Code: MaterialVolcano_v40    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -69,6 +69,11 @@ on:
 permissions:
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   ENVIRONMENT: ${{ inputs.environment }}
@@ -366,7 +371,9 @@ jobs:
       gh-secrets-environment: ${{ inputs.environment }} # The GitHub environment that secrets are pulled from
       release-tag: ${{ inputs.tag }}
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.SERVICE_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -388,6 +395,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.tag }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v25    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v26    DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -43,6 +43,11 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
+  # Required for update-deployment-board
+  # TODO: Remove once techhub deployments are fully functional
+  repository-projects: write
+  issues: write
+  actions: read
 
 env:
   DEPLOYMENT_DESC: 'Destroying <project-name> ${{ inputs.tf-targets }} ${{ inputs.root-module }} via Terraform at ${{ inputs.branch-tag-sha }}' # TODO: Replace <project-name> with your project
@@ -370,7 +375,9 @@ jobs:
       release-tag: ${{ inputs.branch-tag-sha }}
       title-of-teams-post: 'Destroy <<PROJECT_NAME>> ${{ inputs.tf-targets }} @${{ inputs.branch-tag-sha }} in ${{ inputs.root-module }}' # TODO:  Replace <<PROJECT_NAME>> and verify title to ensure it is descriptive/readable.
       post-status-in-deployment-notifications-channel: false
-      # Inputs for Tech Hub deployment tracking
+      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
+      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
+      # Inputs for TechHub deployment tracking
       # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
       # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
 
@@ -391,6 +398,3 @@ jobs:
       #     { "name": "Actor", "value": "${{ github.actor }}" },
       #     { "name": "Version", "value": "${{ inputs.branch-tag-sha }}" }
       #   ]
-    secrets:
-      MS_TEAMS_URI: ${{ vars.MS_TEAMS_URI }}
-      DEPLOY_NOTIFICATIONS_CHANNEL: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}


### PR DESCRIPTION
- Update actions versions to use the node20 version
- Add an input for ms-teams-uri & deploy-notifications-channel for the finish reusable workflows.  These are mainly defined as variables now but we're still treating them as secrets.  Allow caller to provide it either way. +semver:minor
- Adding a step to each reusable workflow to print out the value of each input to make it easier to see what the workflow will be using
- Add update-deployment-board permissions to the deployment workflows with a TODO to remove once we are ready to switch to techhub deploys (this affected at least one team)