### PR TITLE
WIP - ARCH-2065 - Skip update-deployment-board step

### DIFF
--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -13,8 +13,8 @@
 #      title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.AZ_APP_NAME }} ${{ inputs.tag }} to ${{ inputs.environment-or-target }}'
 #      post-status-in-deployment-notifications-channel: true
 #      timezone: america/denver
-#      deployment-board-number: 1
-#      deployable-type: 'API'
+#      deployment-board-number: 1 # DEPRECATED
+#      deployable-type: 'API'     # DEPRECATED
 #      custom-facts-for-team-channel: |
 #      [
 #        { "name": "Workflow", "value": "${{ github.workflow }}" },
@@ -67,17 +67,25 @@ on:
         type: string
         default: 'america/denver'
       deployment-board-number:
-        description: 'The number of the deployment board that should be updated.  Defaults to 1.'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          Set to -1 to skip updating the board (useful when moving to TechHub deployments).
+          The number of the deployment board that should be updated.  Defaults to 1.
         required: false
         type: number
         default: 1
       deployable-type:
-        description: 'Identifier if there are multiple deployables in the repo, like MFE, DB, API.  Defaults to an empty string for single deployables.'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          Identifier if there are multiple deployables in the repo, like MFE, DB, API.  
+          Defaults to an empty string for single deployables.
         required: false
         type: string
         default: ''
       deployable-label:
-        description: 'Deployment board additional label for delete, destroy, or custom label.'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          Deployment board additional label for delete, destroy, or custom label.
         required: false
         type: string
         default: null
@@ -87,12 +95,16 @@ on:
         type: string
         default: null
       enable-deployment-slot-tracking:
-        description: 'Enable App Service deployment slot tracking on deployment board? [true|false]'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          Enable App Service deployment slot tracking on deployment board? [true|false].
         required: false
         type: boolean
         default: false
       slot-swapped-with-production-slot:
-        description: 'Did this deployment swap slots with production slot? Set to true for swapping slot immediately with production slot. [true|false]'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          Did this deployment swap slots with production slot? Set to true for swapping slot immediately with production slot. [true|false].
         required: false
         type: boolean
         default: false
@@ -102,7 +114,9 @@ on:
         required: false
         default: 'production'
       source-slot:
-        description: 'The source slot that was deployed to [production|blue|yellow|canary|red|loadtest|predeploy|your-custom-slot]'
+        description: |
+          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
+          The source slot that was deployed to [production|blue|yellow|canary|red|loadtest|predeploy|your-custom-slot].
         type: string
         required: false
         default: 'production'
@@ -124,7 +138,7 @@ on:
         required: false
         type: string
       deploy-notifications-channel:
-        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the secret DEPLOY_NOTIFICATIONS_CHANNEL must be provided.  This secret is deprecated because this value is defined as a variable at the org level.'
+        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the secret DEPLOY_NOTIFICATIONS_CHANNEL must be provided.  The corresponding secret is deprecated because this value is defined as a variable at the org level.'
         required: false
         type: string
     secrets:
@@ -203,8 +217,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update deployment board
-        if: always()
+      # TODO:  Remove update-deployment-board functionality when techhub deployments are ready
+      #        - Remove this step and the next step once techhub deployments are ready
+      #        - Remove the deprecated inputs & all their references in this workflow
+      #          (deployment-board-number, deployable-type, deployable-label, enable-deployment-slot-tracking, slot-swapped-with-production-slot, source-slot)
+      - name: Update deployment board if deployment-board-number is >= 1
+        if: always() && fromJSON(inputs.deployment-board-number) >= 1
         uses: im-open/update-deployment-board@v1.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -220,6 +238,10 @@ jobs:
           target-slot: ${{ inputs.target-slot }}
           source-slot: ${{ inputs.source-slot }}
           timezone: ${{ inputs.timezone }}
+
+      - name: Skip deployment board update if deployment-board-number is < 1
+        if: always() && fromJSON(inputs.deployment-board-number) < 1
+        run: echo "Skip updating the deployment board since the board number is set to ${{ inputs.deployment-board-number }}."
 
       # Only run this step if TechHub metadata.name value
       # and a metadata.instance value are provided

--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -476,7 +476,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1.  Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -292,7 +292,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -416,7 +416,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -231,7 +231,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -428,7 +428,7 @@ jobs:
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -241,7 +241,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -380,7 +380,7 @@ jobs:
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -383,7 +383,7 @@ jobs:
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1
+      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
       # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |


### PR DESCRIPTION
Adding a way to skip the update-deployment-board step in the im-reusable-finish-deployment-workflow without creating a breaking change yet.  There are around 70 usages of this reusable workflow and about half of those rely on the default value being 1 for the `deployment-board-number` input which is why it's a little hacky with the -1.  If we prefer a different input like `skip-deployment-board-update` could be temporarily introduced and then removed with the rest of the update-deployment-board functionality.  I don't think this will be very long-lived whichever way we go.

I added a second step that spells out why the first step might be skipped just for a little bit of additional info that can clue users into the fact that skipping is now an option.  That step can be removed once we make the breaking change to remove all update-deployment-board functionality.

This was tested in 1UP:
- [Workflow that skips update-deployment-board by setting board number to -1](https://github.com/im-practices/1UP/actions/runs/8636144478/job/23679495959#step:7:2)
- [Workflow that uses update-deployment-board by setting board number to 2](https://github.com/im-practices/1UP/actions/runs/8637434840/job/23679601756#step:6:1)

Both of those deployments are choking on the create-github-deployment step (I think because of all the current github incidents) but the update-deployment-board is happy.
