### PR TITLE
ARCH-2088 - +semver:breaking Changes for TechHub deployments

### DIFF
--- a/.github/workflows/im-reusable-finish-build-workflow.yml
+++ b/.github/workflows/im-reusable-finish-build-workflow.yml
@@ -5,7 +5,7 @@
 # Example Usage in a repo's workflow:
 # jobs:
 #  setup-deployment-workflow:
-#    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v2
+#    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v3
 #    with:
 #      runs-on: im-linux
 #      next-version: ${{ needs.build-deployment-artifacts.outputs.NEXT_VERSION }}

--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -1,10 +1,10 @@
 # The purpose of this reusable job is to run the final steps of a deployment workflow
-# which includes updating the deployment board and posting a status to Teams.
+# which includes updating the github deployments in TechHub and posting a status to Teams.
 
 # Example Usage in a repo's workflow:
 # jobs:
-#  finish-deployment-workflow:
-#    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+#  update-github-deployments-and-send-teams-notification:
+#    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
 #    with:
 #      runs-on: im-linux
 #      gh-secrets-environment: ${{ inputs.environment-or-target }}
@@ -13,8 +13,6 @@
 #      title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.AZ_APP_NAME }} ${{ inputs.tag }} to ${{ inputs.environment-or-target }}'
 #      post-status-in-deployment-notifications-channel: true
 #      timezone: america/denver
-#      deployment-board-number: 1 # DEPRECATED
-#      deployable-type: 'API'     # DEPRECATED
 #      custom-facts-for-team-channel: |
 #      [
 #        { "name": "Workflow", "value": "${{ github.workflow }}" },
@@ -28,7 +26,9 @@
 #        { "name": "Version", "value": "${{ inputs.tag }}" }
 #      ]
 #      ms-teams-uri: ${{ vars.MS_TEAMS_URI }}  # Use this input (preferred) or the secret
-#      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}  # The input is the preferred way to provide the URI.  The secret is deprecated.
+#      deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }} # This is an org-level variable
+#      entity: ${{ env.TECHHUB_ENTITY }}
+#      instance: ${{ env.TECHHUB_INSTANCE }}
 
 on:
   workflow_call:
@@ -50,6 +50,22 @@ on:
         description: 'Title of the Teams post that will be used in the team channel and the Deployment Notifications channel.'
         required: true
         type: string
+      deploy-notifications-channel:
+        description: 'The URI for the notifications channel where a status will be posted.'
+        required: true
+        type: string
+      entity:
+        description: 'The TechHub entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.'
+        required: true
+        type: string
+      instance:
+        description: |
+          The value used to create a deployment instance name in the GitHub deployment API.
+          It represents the specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot
+          Generally some combination of deployment-environment, slot-name and AZ region values.
+        required: true
+        type: string
+      
       # Optional Inputs
       runs-on:
         description: 'The runner that this workflow will run on.'
@@ -66,65 +82,6 @@ on:
         required: false
         type: string
         default: 'america/denver'
-      deployment-board-number:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          Set to -1 to skip updating the board (useful when moving to TechHub deployments).
-          The number of the deployment board that should be updated.  Defaults to 1.
-        required: false
-        type: number
-        default: 1
-      deployable-type:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          Identifier if there are multiple deployables in the repo, like MFE, DB, API.  
-          Defaults to an empty string for single deployables.
-        required: false
-        type: string
-        default: ''
-      deployable-label:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          Deployment board additional label for delete, destroy, or custom label.
-        required: false
-        type: string
-        default: null
-      entity:
-        description: 'The catalog-info.yml metadata.name value for mapping in TechHub.'
-        required: false
-        type: string
-        default: null
-      enable-deployment-slot-tracking:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          Enable App Service deployment slot tracking on deployment board? [true|false].
-        required: false
-        type: boolean
-        default: false
-      slot-swapped-with-production-slot:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          Did this deployment swap slots with production slot? Set to true for swapping slot immediately with production slot. [true|false].
-        required: false
-        type: boolean
-        default: false
-      target-slot:
-        description: 'The target slot that was deployed to [production|blue|yellow|canary|red|loadtest|predeploy|your-custom-slot]'
-        type: string
-        required: false
-        default: 'production'
-      source-slot:
-        description: |
-          DEPRECATED.  This input will be removed in the next major version.  Migrate to create-github-deployment by providing instance and entity inputs instead.
-          The source slot that was deployed to [production|blue|yellow|canary|red|loadtest|predeploy|your-custom-slot].
-        type: string
-        required: false
-        default: 'production'
-      instance:
-        description: 'The instance of the deployment.  This is used to create a deployment instance name in the GitHub deployment API.'
-        required: false
-        type: string
-        default: null
       custom-facts-for-team-channel:
         description: The custom facts that will be included in the post in the team's channel.  By default Workflow, Run, Actor and Version are included.
         required: false
@@ -137,16 +94,9 @@ on:
         description: The URI for the teams channel where a status will be posted.  Either this value or the secret MS_TEAMS_URI must be provided.  This input is the preferred way to provide the URI but the secret should be used instead if the value is defined as a secret.
         required: false
         type: string
-      deploy-notifications-channel:
-        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the secret DEPLOY_NOTIFICATIONS_CHANNEL must be provided.  The corresponding secret is deprecated because this value is defined as a variable at the org level.'
-        required: false
-        type: string
     secrets:
       MS_TEAMS_URI:
         description: 'The URI for the teams channel where a status will be posted.  Either this value or the input ms-teams-uri must be provided.  The input is the preferred way to provide the URI but the secret should be used if the value is defined as a secret.'
-        required: false
-      DEPLOY_NOTIFICATIONS_CHANNEL:
-        description: 'The URI for the notifications channel where a status will be posted.  Either this value or the input deploy-notifications-channel must be provided.  This secret is deprecated because this value is defined as a variable at the org level.  Please switch to using the input.'
         required: false
 
 jobs:
@@ -162,10 +112,6 @@ jobs:
             const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
             if (!teamsUri || teamsUri.trim().length === 0){
               core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
-            }
-            const notificationsUri = '${{ inputs.deploy-notifications-channel || secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}';
-            if (!notificationsUri || notificationsUri.trim().length === 0){
-              core.setFailed('The DEPLOY_NOTIFICATIONS_CHANNEL secret or the deploy-notifications-channel input (preferred) must be provided.');
             }
 
       - name: Print inputs
@@ -190,13 +136,6 @@ jobs:
             printInput('runs-on', '${{ inputs.runs-on }}');
             printInput('post-status-in-deployment-notifications-channel', '${{ inputs.post-status-in-deployment-notifications-channel }}');
             printInput('timezone', '${{ inputs.timezone }}');
-            printInput('deployment-board-number', '${{ inputs.deployment-board-number }}');
-            printInput('deployable-type', '${{ inputs.deployable-type }}');
-            printInput('deployable-label', '${{ inputs.deployable-label }}');
-            printInput('enable-deployment-slot-tracking', '${{ inputs.enable-deployment-slot-tracking }}');
-            printInput('slot-swapped-with-production-slot', '${{ inputs.slot-swapped-with-production-slot }}');
-            printInput('target-slot', '${{ inputs.target-slot }}');
-            printInput('source-slot', '${{ inputs.source-slot }}');
             printInput('instance', '${{ inputs.instance }}');
             printInput('ms-teams-uri', '${{ inputs.ms-teams-uri }}');
             printInput('deploy-notifications-channel', '${{ inputs.deploy-notifications-channel }}');
@@ -206,7 +145,6 @@ jobs:
 
             core.startGroup('Reusable workflow secrets');
             printInput('MS_TEAMS_URI', '${{ secrets.MS_TEAMS_URI }}');
-            printInput('DEPLOY_NOTIFICATIONS_CHANNEL', '${{ secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}');
             core.endGroup();
         env:
           CUSTOM_FACTS_TEAMS: ${{ inputs.custom-facts-for-team-channel }}
@@ -217,36 +155,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO:  Remove update-deployment-board functionality when techhub deployments are ready
-      #        - Remove this step and the next step once techhub deployments are ready
-      #        - Remove the deprecated inputs & all their references in this workflow
-      #          (deployment-board-number, deployable-type, deployable-label, enable-deployment-slot-tracking, slot-swapped-with-production-slot, source-slot)
-      - name: Update deployment board if deployment-board-number is >= 1
-        if: always() && fromJSON(inputs.deployment-board-number) >= 1
-        uses: im-open/update-deployment-board@v1.7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          environment: ${{ inputs.deployment-environment }}
-          board-number: ${{ inputs.deployment-board-number }}
-          ref: ${{ inputs.release-tag }}
-          ref-type: 'tag'
-          deployable-type: ${{ inputs.deployable-type }}
-          deploy-label: ${{ inputs.deployable-label }}
-          deploy-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
-          enable-deployment-slot-tracking: ${{ inputs.enable-deployment-slot-tracking }}
-          slot-swapped-with-production-slot: ${{ inputs.slot-swapped-with-production-slot }}
-          target-slot: ${{ inputs.target-slot }}
-          source-slot: ${{ inputs.source-slot }}
-          timezone: ${{ inputs.timezone }}
-
-      - name: Skip deployment board update if deployment-board-number is < 1
-        if: always() && fromJSON(inputs.deployment-board-number) < 1
-        run: echo "Skip updating the deployment board since the board number is set to ${{ inputs.deployment-board-number }}."
-
       # Only run this step if TechHub metadata.name value
       # and a metadata.instance value are provided
       - name: Create GitHub Deployment for TechHub
-        if: ${{ inputs.entity != null && (inputs.instance != null || inputs.target-slot != null) }}
         uses: im-open/create-github-deployment@v1.0
         with:
           workflow-actor: ${{ github.actor }} # This will add the user who kicked off the workflow to the deployment payload
@@ -256,7 +167,7 @@ jobs:
           deployment-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           deployment-description: 'Deployment to the ${{ inputs.deployment-environment }} environment of ${{ inputs.release-tag }}'
           entity: ${{ inputs.entity }}
-          instance: ${{ inputs.instance || inputs.target-slot }}
+          instance: ${{ inputs.instance }}
 
       - name: Configure facts for team's notification channel
         if: always()
@@ -356,7 +267,7 @@ jobs:
           title: ${{ inputs.title-of-teams-post }}
           workflow-status: ${{ steps.conclusion.outputs.workflow_conclusion }}
           workflow-type: Deploy
-          teams-uri: ${{ inputs.deploy-notifications-channel || secrets.DEPLOY_NOTIFICATIONS_CHANNEL }}
+          teams-uri: ${{ inputs.deploy-notifications-channel }}
           timezone: ${{ inputs.timezone }}
           include-default-facts: false # This cuts down on the message size for the prod room
           custom-facts: ${{ steps.deployment-channel-facts.outputs.facts }}

--- a/.github/workflows/im-reusable-setup-build-workflow.yml
+++ b/.github/workflows/im-reusable-setup-build-workflow.yml
@@ -6,7 +6,7 @@
 # Example Usage in a repo's workflow:
 # jobs:
 #  setup-build-workflow:
-#    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v2
+#    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v3
 #    with:
 #     default-branch: main
 #     tag-prefix: none

--- a/.github/workflows/im-reusable-setup-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-setup-deployment-workflow.yml
@@ -6,7 +6,7 @@
 # Example Usage in a repo's workflow:
 # jobs:
 #  setup-deployment-workflow:
-#    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+#    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
 #    with:
 #      runs-on: im-linux
 #      ref-to-deploy: v1.2.3

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -1,4 +1,4 @@
-# Workflow Code: LoathsomeSnipe_v54    DO NOT REMOVE
+# Workflow Code: LoathsomeSnipe_v55    DO NOT REMOVE
 # Purpose:
 #    Automatically checks out the code, builds, run tests and creates artifacts
 #    which are uploaded to a GH release when commits are pushed to a PR. In the
@@ -54,7 +54,7 @@ jobs:
   #   2 - Print a workflow summary
   #   3 - Generate the next version for the repo
   setup-build-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v3
     with:
       tag-prefix: 'v' # TODO: If you prefix your tags like (mfe/db/etc) uncomment and add that value here
       # default-branch: main # TODO:  Update and include this argument if default branch is different
@@ -601,7 +601,7 @@ jobs:
   finish-build:
     if: always() && needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
     needs: [setup-build-workflow, dotnet-test, jest]
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v3
     with:
       next-version: ${{ needs.setup-build-workflow.outputs.NEXT_VERSION }}
       title-of-teams-post: '<project-name> CI Build' # TODO: Replace <project-name>

--- a/workflow-templates/im-build-npm-package.yml
+++ b/workflow-templates/im-build-npm-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: GloomyBadger_v33    DO NOT REMOVE
+# Workflow Code: GloomyBadger_v34    DO NOT REMOVE
 # Purpose:
 #    Automatically calculates the next semantic version, runs an npm ci, an npm run tests
 #    if there is one, an npm publish and then pushes a latest tag for main builds. When the
@@ -42,7 +42,7 @@ jobs:
   #   2 - Print a workflow summary
   #   3 - Generate the next version for the repo
   setup-build-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v3
     with:
       tag-prefix: 'none' # TODO: verify your prefix, the new ci workflows add v automatically but npm packages typically won't have a prefix
       # default-branch: main # TODO:  Update and include this argument if default branch is different
@@ -137,7 +137,7 @@ jobs:
   finish-build:
     if: always() && needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
     needs: [setup-build-workflow, build-and-publish-to-gpr]
-    uses:  im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v2
+    uses:  im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v3
     with:
       next-version: ${{ needs.build-and-publish-to-gpr.outputs.NEXT_VERSION }}
       title-of-teams-post: 'Build and Publish <project-name> to GH Packages' # TODO: Replace <project-name> 

--- a/workflow-templates/im-build-nuget-package.yml
+++ b/workflow-templates/im-build-nuget-package.yml
@@ -1,4 +1,4 @@
-# Workflow Code: TrustingCockroach_v44    DO NOT REMOVE
+# Workflow Code: TrustingCockroach_v45    DO NOT REMOVE
 # Purpose:
 #    Automatically builds the project and runs tests with code coverage. If
 #    everything is green, a new semantic version is calculated and a new package
@@ -44,7 +44,7 @@ jobs:
   #   2 - Print a workflow summary
   #   3 - Generate the next version for the repo
   setup-build-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-build-workflow.yml@v3
     with:
       tag-prefix: 'none'
       # default-branch: main # TODO:  Update and include this argument if default branch is different
@@ -215,7 +215,7 @@ jobs:
   finish-build:
     if: always() && needs.setup-build-workflow.outputs.CONTINUE_WORKFLOW == 'true'
     needs: [setup-build-workflow, build-test-publish]
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-build-workflow.yml@v3
     with:
       next-version: ${{ needs.setup-build-workflow.outputs.NEXT_VERSION }}
       title-of-teams-post: 'Build and Publish <project-name> to GH Packages' # TODO: Replace <project-name>

--- a/workflow-templates/im-deploy-az-app-manually.yml
+++ b/workflow-templates/im-deploy-az-app-manually.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmbitiousLizard_v50    DO NOT REMOVE
+# Workflow Code: AmbitiousLizard_v51    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified
@@ -19,8 +19,7 @@
 #    - Make sure the az secrets have been added to the environment in GitHub
 #    - Make sure the scm restrictions (terraform) include the prod github runners (previously it had just octopus)
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#      Generally one board should be set up per app service/function in the repository.
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Manually deploy AZ App # TODO: If there are multiple app service/functions in the repo, append the project name (svc/bff/mfe/etc) to this and the actual file name
 run-name: Deploy ${{ inputs.tag }} to ${{ inputs.environment-or-target }} AZ App
@@ -66,12 +65,8 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -83,7 +78,7 @@ jobs:
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch
   #       and that the corresponding release is production ready (not pre-release or a draft).
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment-or-target }}
@@ -460,7 +455,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, deploy-code]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment-or-target }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -469,15 +464,12 @@ jobs:
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.AZ_APP_NAME }} ${{ inputs.tag }} to ${{ inputs.environment-or-target }}' # TODO:  Verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1.  Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-az-database.yml
+++ b/workflow-templates/im-deploy-az-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BetrayedCod_v35    DO NOT REMOVE
+# Workflow Code: BetrayedCod_v36    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures
 #    tags are valid for production deployments and runs the migrations against
@@ -16,8 +16,7 @@
 #    - Make sure the az secrets have been added to the environment
 #    - Make sure the prod runners have access to the database with a 'azurerm_sql_virtual_network_rule'
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#      Generally one board should be set up per database in the repository.
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Deploy Database to Azure # TODO: If there are multiple az databases in the repo, append the db name to this workflow's file name and update the workflow name below
 run-name: Deploy ${{ inputs.tag }} to ${{ inputs.environment }} AZ DB
@@ -61,12 +60,8 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -80,7 +75,7 @@ jobs:
   #   1 - Verify the tag provided is a valid ref.
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch.
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag == 0 && github.ref_name || inputs.tag }}
       deployment-environment: ${{ inputs.environment-or-target }}
@@ -276,7 +271,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, deploy-az-db]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment-or-target }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -285,15 +280,12 @@ jobs:
       title-of-teams-post: 'Deploy ${{ needs.deploy-az-db.outputs.DB_NAME }} ${{ inputs.tag == 0 && github.ref_name || inputs.tag }} to ${{ inputs.environment-or-target }}' # TODO:  Verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-files-to-az-storage-account.yml
+++ b/workflow-templates/im-deploy-files-to-az-storage-account.yml
@@ -1,4 +1,4 @@
-# Workflow Code: BubblyGreyhound_v28    DO NOT REMOVE
+# Workflow Code: BubblyGreyhound_v29    DO NOT REMOVE
 # Purpose:
 #    Checks out the repository and deploys a directory to the
 #    specified storage account when someone kicks it off manually.
@@ -12,7 +12,7 @@
 #
 # TODO: Prerequisites:
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Deploy Files to Azure Storage
 run-name: Deploy ${{ inputs.branch-tag-sha }} Files to ${{ inputs.environment }} AZ Storage
@@ -41,10 +41,6 @@ permissions:
   contents: read
   # Required for create-github-deployment
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -114,8 +110,8 @@ jobs:
           release-ref: ${{ env.GITHUB_REF }}
           deployment-status: ${{ job.status }}
           deployment-description: 'Deployment to the ${{ env.ENVIRONMENT }} environment of ${{ env.GITHUB_REF }}'
-          entity: '' # TODO: Fill this out with the catalog-info.yml's metadata.name value
-          instance: file-storage
+          entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+          instance: 'file-storage'
 
       - name: Azure logout
         if: always() && steps.login.outcome == 'success'

--- a/workflow-templates/im-deploy-iis-website.yml
+++ b/workflow-templates/im-deploy-iis-website.yml
@@ -1,4 +1,4 @@
-# Workflow Code: FuzzyDragon_v47    DO NOT REMOVE
+# Workflow Code: FuzzyDragon_v48    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release
 #    with the specified tags, makes changes to any configuration files for the specified environments,
@@ -16,8 +16,7 @@
 # TODO: Prerequisites:
 #     - Make sure the host IIS server has been prepped to accept incoming WinRM Requests
 #     - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#     - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#       Generally one board should be set up per IIS site in the repository.
+#     - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 #     - The target server must be domain joined. If this is not the case already, create an ITHD ticket to have it joined to
 #       the ExtendHealth domain for service account authentication
 #     - Create an ITHD ticket to have an ExtendHealth Active directory service account created for each deployment environment.
@@ -68,12 +67,8 @@ on:
   #   types: [<deployable_name>_deploy] # TODO: Replace <deployable_name>.  This will be used in the 'Deploy Multiple Items' workflow to target this deployment workflow.
 
 permissions:
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -87,7 +82,7 @@ jobs:
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch
   #       and that the corresponding release is production ready (not pre-release or a draft).
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}
@@ -400,7 +395,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, deploy-site-to-machine]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -409,15 +404,12 @@ jobs:
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.WEBSITE_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-multiple-items-at-once.yml
+++ b/workflow-templates/im-deploy-multiple-items-at-once.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MercifulLlama_v18    DO NOT REMOVE
+# Workflow Code: MercifulLlama_v19    DO NOT REMOVE
 # Purpose:
 #    This is only required when teams have separate deployable artifacts (db/mfe/api/etc.)
 #    but they need each item to be deployed together.
@@ -51,7 +51,7 @@ jobs:
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch
   #       and that the corresponding release is production ready (not pre-release or a draft).
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}

--- a/workflow-templates/im-deploy-on-prem-database.yml
+++ b/workflow-templates/im-deploy-on-prem-database.yml
@@ -1,4 +1,4 @@
-# Workflow Code: AmazedPiglet_v36    DO NOT REMOVE
+# Workflow Code: AmazedPiglet_v37    DO NOT REMOVE
 # Purpose:
 #    Gathers the required approvals from stakeholders and attestors, ensures tags
 #    are valid for production deployments and runs the migrations against an on-prem
@@ -17,8 +17,7 @@
 #    - Make sure the database login secrets have been added to Vault and are accessible from our self-hosted runners.
 #      See https://github.com/im-practices/git-er-done/blob/main/actions/hashicorp-vault-integration.md for information on how to do that.
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#      Generally one board should be set up per database in the repository.
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Deploy Database to On-Prem Server # TODO: If there are multiple on prem databases in the repo, append the db name to this workflow's file name and update this name
 run-name: Deploy ${{ inputs.tag }} to ${{ inputs.environment }}
@@ -61,12 +60,8 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -82,7 +77,7 @@ jobs:
   #   1 - Verify the tag provided is a valid ref.
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch.
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}
@@ -215,7 +210,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [deploy-on-prem-db]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -224,15 +219,12 @@ jobs:
       title-of-teams-post: 'Deploy ${{ needs.deploy-on-prem-db.outputs.DB_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
+++ b/workflow-templates/im-deploy-tf-auto-apply-main-to-dev-on-merge.yml
@@ -1,4 +1,4 @@
-# Workflow Code: IrritableEagle_v37    DO NOT REMOVE
+# Workflow Code: IrritableEagle_v38    DO NOT REMOVE
 # Purpose:
 #    Automatically runs a terraform apply -auto-approve with the changes
 #    in the PR against the dev environment when a PR is merged to main.
@@ -11,7 +11,7 @@
 #
 # TODO: Prerequisites:
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Auto Apply main branch to Dev on PR Merge
 run-name: Apply dev terraform from main
@@ -25,13 +25,10 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required create-github-deployment
+  # Required for create-github-deployment
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
+
 env:
   TIMEZONE: 'america/denver' # TODO: Verify timezone
   PAGERDUTY_WINDOW_IN_MIN: 10 # TODO: Verify the length of your PD Maintenance Window
@@ -152,5 +149,5 @@ jobs:
           release-ref: 'main'
           deployment-status: ${{ job.status }}
           deployment-description: 'Deployment to the Dev environment of the main branch'
-          entity: '' # TODO: Fill this out with the catalog-info.yml's metadata.name value
+          entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
           instance: ${{ inputs.instance }}

--- a/workflow-templates/im-deploy-tf-manual-apply.yml
+++ b/workflow-templates/im-deploy-tf-manual-apply.yml
@@ -1,4 +1,4 @@
-# Workflow Code: InsaneHamster_v49    DO NOT REMOVE
+# Workflow Code: InsaneHamster_v50    DO NOT REMOVE
 # Purpose:
 #    Deploys the terraform from a specified root module at a
 #    specified when someone kicks off the workflow manually.
@@ -11,7 +11,7 @@
 #
 # TODO: Prerequisites:
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#    - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 
 name: Apply Terraform
 run-name: Apply ${{ inputs.root-module }} terraform from ${{ inputs.branch-tag-sha }}
@@ -39,12 +39,8 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -75,7 +71,7 @@ jobs:
   #   1 - Verify the branch/tag/sha provided is a valid ref.
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch.
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.branch-tag-sha }}
       deployment-environment: ${{ inputs.root-module }}
@@ -412,7 +408,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, tf-apply]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.root-module }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -422,14 +418,11 @@ jobs:
       post-status-in-deployment-notifications-channel: false
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-windows-files.yml
+++ b/workflow-templates/im-deploy-windows-files.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MysteriousStranger_v17    DO NOT REMOVE
+# Workflow Code: MysteriousStranger_v18    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -12,8 +12,7 @@
 #
 # TODO: Prerequisites:
 #     - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#     - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#       Generally one board should be set up per windows service in the repository.
+#     - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 #     - The target server must be domain joined. If this is not the case already, create an ITHD ticket to have it joined to
 #       the ExtendHealth domain for service account authentication
 #     - Create an ITHD ticket to have an ExtendHealth Active directory service account created for each deployment environment.
@@ -64,12 +63,8 @@ on:
   #   types: [<deployable_name>_deploy] # TODO: Replace <deployable_name>.  This will be used in the 'Deploy Multiple Items' workflow to target this deployment workflow.
 
 permissions:
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -83,7 +78,7 @@ jobs:
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch
   #       and that the corresponding release is production ready (not pre-release or a draft).
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}
@@ -225,7 +220,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [setup-deployment-workflow, deploy-files]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -234,15 +229,12 @@ jobs:
       title-of-teams-post: 'Deploy <<PROJECT NAME>> files @${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Replace <<PROJECT_NAME>> and verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-deploy-windows-service.yml
+++ b/workflow-templates/im-deploy-windows-service.yml
@@ -1,4 +1,4 @@
-# Workflow Code: MaterialVolcano_v41    DO NOT REMOVE
+# Workflow Code: MaterialVolcano_v42    DO NOT REMOVE
 # Purpose:
 #    Gathers various stakeholder and attestor approvals, downloads artifacts from a release with the
 #    specified tags, makes changes to any configuration files for the specified environments, stops
@@ -15,8 +15,7 @@
 #
 # TODO: Prerequisites:
 #     - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
-#     - Set up a deployment board if it does not already exist: https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
-#       Generally one board should be set up per windows service in the repository.
+#     - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 #     - The target server must be domain joined. If this is not the case already, create an ITHD ticket to have it joined to
 #       the ExtendHealth domain for service account authentication
 #     - Create an ITHD ticket to have an ExtendHealth Active directory service account created for each deployment environment.
@@ -67,12 +66,8 @@ on:
   #   types: [<deployable_name>_deploy] # TODO: Replace <deployable_name>.  This will be used in the 'Deploy Multiple Items' workflow to target this deployment workflow.
 
 permissions:
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -86,7 +81,7 @@ jobs:
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch
   #       and that the corresponding release is production ready (not pre-release or a draft).
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.tag }}
       deployment-environment: ${{ inputs.environment }}
@@ -364,7 +359,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, deploy-service-to-machine]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.environment }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -373,15 +368,12 @@ jobs:
       title-of-teams-post: 'Deploy ${{ needs.set-vars.outputs.SERVICE_NAME }} ${{ inputs.tag }} to ${{ inputs.environment }}' # TODO:  Verify title to ensure it is descriptive/readable.
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # post-status-in-deployment-notifications-channel: true # TODO:  Include this arg and set to false if you do not want a status post in the Deployment Notifications channel for prod deploys
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-run-tf-destroy.yml
+++ b/workflow-templates/im-run-tf-destroy.yml
@@ -1,4 +1,4 @@
-# Workflow Code: HostileMacaw_v28    DO NOT REMOVE
+# Workflow Code: HostileMacaw_v29    DO NOT REMOVE
 # Purpose:
 #    Destroys the resources created by a terraform configuration when someone kicks it off manually.
 #
@@ -41,12 +41,8 @@ permissions:
   # Required for secretless azure access and deploys
   id-token: write
   contents: read
-  # Required for create-github-deployment
+  # Required for create-github-deployment (in the reusable update-github-deployments-and-send-teams-notification job)
   deployments: write
-  # Required for update-deployment-board
-  # TODO: Remove once techhub deployments are fully functional
-  repository-projects: write
-  issues: write
   actions: read
 
 env:
@@ -77,7 +73,7 @@ jobs:
   #   1 - Verify the branch/tag/sha provided is a valid ref.
   #   2 - If deploying to a production environment, verify the tag is reachable from the default branch.
   setup-deployment-workflow:
-    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-setup-deployment-workflow.yml@v3
     with:
       ref-to-deploy: ${{ inputs.branch-tag-sha }}
       deployment-environment: ${{ inputs.root-module }}
@@ -367,7 +363,7 @@ jobs:
   update-github-deployments-and-send-teams-notification:
     needs: [set-vars, tf-apply]
     if: always()
-    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v2
+    uses: im-practices/.github/.github/workflows/im-reusable-finish-deployment-workflow.yml@v3
     with:
       # Required Inputs
       deployment-environment: ${{ inputs.root-module }} # The environment/target that was deployed to (dev, qa, stage, stage-secondary, uat, demo, prod, prod-secondary)
@@ -377,14 +373,11 @@ jobs:
       post-status-in-deployment-notifications-channel: false
       ms-teams-uri: ${{ vars.MS_TEAMS_URI }}
       deploy-notifications-channel: ${{ vars.DEPLOY_NOTIFICATIONS_CHANNEL }}
-      # Inputs for TechHub deployment tracking
-      # entity: '' # TODO: This the catalog-info.yml value in metadata.name value
-      # instance: '' # TODO: This the specific target deployment location, i.e., testing-slot-1, primary-app-service, failover-slot-2, NA26-production-slot
+      entity: '' # TODO: The TechHub (catalog-info.yml) entity that is being deployed.  This value should match the metadata.name of the entity defined in catalog-info.yml.
+      instance: '' # TODO: A specific target deployment location e.g., primary, primary-app-service, testing-slot, failover-slot-2, NA26, NA27-production-slot.  Generally some combination of deployment-environment, slot-name and AZ region values.
 
       # Optional Inputs with their default values.  These items can be removed if the default value does not need to be adjusted.
       # timezone: 'america/denver'                            # TODO:  Include this argument and update if your timezone is not america/denver
-      # deployment-board-number: 1                            # TODO:  Include this argument and update if your deployment board is not 1. Set to -1 to skip updating the deployment board (useful when migrating to the new TechHub deployment tracking).
-      # deployable-type: ''                                   # TODO:  If there are multiple deployables in the repository, add a string type like MFE/DB/API for the deployment board
       # TODO:  These are the custom facts that will be included the different Teams posts by default.  If adjusting the facts that are supplied, they must be a valid JSON array.
       # custom-facts-for-team-channel: |
       #   [

--- a/workflow-templates/im-run-validate-deployed-terraform.yml
+++ b/workflow-templates/im-run-validate-deployed-terraform.yml
@@ -1,4 +1,4 @@
-# Workflow Code: ShinySQUIRREL_v25    DO NOT REMOVE
+# Workflow Code: ShinySQUIRREL_v26    DO NOT REMOVE
 # Purpose:
 #    Validates that the deployed terraform matches what is supposed to be deployed
 #    when it runs at a scheduled time or when someone kicks it off manually.
@@ -12,8 +12,7 @@
 #    - Terraform (Core Template)
 #
 # TODO Prerequisites:
-#    - This workflow relies on a Deployment Board being set up to determine what should be currently deployed to the environment
-#      https://github.com/im-practices/git-er-done/blob/main/docs/actions/deployment-board.md
+#    - Create an entity in this repo's catalog-info.yml that represents what is being deployed if it does not already exist
 #    - Ensure each of the repo-level and env-level secrets used in this workflow have been populated by an admin in your repository.
 
 name: Validate Deployed Terraform
@@ -67,6 +66,7 @@ jobs:
         working-directory: '${{ env.TF_WORKING_DIR }}'
 
     steps:
+      # TODO:  SWAT - Need a replacement for determining which release is the latest
       - name: Determine latest release
         id: get-latest
         uses: actions/github-script@v7


### PR DESCRIPTION
- Remove deprecated inputs from the reusable finish deployment workflow
- Make techhub deployment related inputs required in the finish deployment workflow
- Update workflow templates to use latest reusable workflow versions (@v3) & modify inputs accordingly
- Update permissions in each of the "deploy" templates now that deployment-board permissions are no longer needed