### PR TITLE
No longer require ms-teams-uri in finish deployment

### DIFF
--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -99,12 +99,12 @@ on:
         required: false
         type: string
       ms-teams-uri:
-        description: The URI for the teams channel where a status will be posted.  Either this value or the secret MS_TEAMS_URI must be provided.  This input is the preferred way to provide the URI but the secret should be used instead if the value is defined as a secret.
+        description: The URI for the teams channel where a status will be posted.  This input is the preferred way to provide the URI but the secret should be used instead if the value is defined as a secret.
         required: false
         type: string
     secrets:
       MS_TEAMS_URI:
-        description: 'The URI for the teams channel where a status will be posted.  Either this value or the input ms-teams-uri must be provided.  The input is the preferred way to provide the URI but the secret should be used if the value is defined as a secret.'
+        description: 'The URI for the teams channel where a status will be posted.  The input is the preferred way to provide the URI but the secret should be used if the value is defined as a secret.'
         required: false
 
 jobs:
@@ -112,16 +112,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.gh-secrets-environment }}
     steps:
-      - name: Check for missing inputs
-        uses: actions/github-script@v7
-        with:
-          script: |
-            // Some teams have these as a secret and some as a var, allow both ways but check at least one is present
-            const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
-            if (!teamsUri || teamsUri.trim().length === 0){
-              core.setFailed('The MS_TEAMS_URI secret or the ms-teams-uri input (preferred) must be provided.');
-            }
-
       - name: Print inputs
         uses: actions/github-script@v7
         with:
@@ -210,7 +200,7 @@ jobs:
           FACTS: ${{ inputs.custom-facts-for-team-channel }}
 
       - name: Send status to team's notification channel
-        if: always()
+        if: always() && (inputs.ms-teams-uri || secrets.MS_TEAMS_URI)
         uses: im-open/post-status-to-teams-action@v1.4
         with:
           title: ${{ inputs.title-of-teams-post }}


### PR DESCRIPTION
Make the ms-teams-uri inputs option since teams can no longer create new integrations.