### PR TITLE
Teams Check Fix

### DIFF
--- a/.github/workflows/im-reusable-finish-deployment-workflow.yml
+++ b/.github/workflows/im-reusable-finish-deployment-workflow.yml
@@ -112,6 +112,20 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     environment: ${{ inputs.gh-secrets-environment }}
     steps:
+      - name: Check if workflow should post to teams
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Some teams have these as a secret and some as a var, allow either way but if not present do not post
+            const teamsUri = '${{ inputs.ms-teams-uri || secrets.MS_TEAMS_URI }}';
+            if (!teamsUri || teamsUri.trim().length === 0){
+              core.info('The MS_TEAMS_URI secret or the ms-teams-uri input must be provided to post to teams.  A post will not be made.');
+              core.exportVariable('POST_TO_TEAMS', false);
+            }
+            else {
+              core.exportVariable('POST_TO_TEAMS', true);
+            }
+
       - name: Print inputs
         uses: actions/github-script@v7
         with:
@@ -200,7 +214,7 @@ jobs:
           FACTS: ${{ inputs.custom-facts-for-team-channel }}
 
       - name: Send status to team's notification channel
-        if: always() && (inputs.ms-teams-uri || secrets.MS_TEAMS_URI)
+        if: always() && env.POST_TO_TEAMS == 'true'
         uses: im-open/post-status-to-teams-action@v1.4
         with:
           title: ${{ inputs.title-of-teams-post }}


### PR DESCRIPTION
Fix for the teams check. The `if` did not like the same syntax as the input or the js code above because `if` does not have access to the `secrets` context.
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability