### PR TITLE
Proposal: Add "Authenticate with GitHub Packages" step in other jobs for dotnet CI workflow template

### DIFF
--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -257,6 +257,13 @@ jobs:
           path: ~/.nuget/packages
           key: ${{ needs.nuget-cache.outputs.NUGET_CACHE_KEY }}
 
+      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
+      # - name: Authenticate with GitHub Packages
+      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
+      #   with:
+      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
+      #     orgs: ''
+
       - name: Build Database
         uses: im-open/build-database-ci-action@v3.3
         with:
@@ -533,6 +540,13 @@ jobs:
       - name: Rebuild Node Modules
         working-directory: '.' # TODO:  Update if package-lock.json is not at the root of the project
         run: npm rebuild
+
+      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
+      # - name: Authenticate with GitHub Packages
+      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
+      #   with:
+      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
+      #     orgs: ''
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4

--- a/workflow-templates/im-build-dotnet-ci.yml
+++ b/workflow-templates/im-build-dotnet-ci.yml
@@ -257,13 +257,6 @@ jobs:
           path: ~/.nuget/packages
           key: ${{ needs.nuget-cache.outputs.NUGET_CACHE_KEY }}
 
-      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
-      #   with:
-      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
-      #     orgs: ''
-
       - name: Build Database
         uses: im-open/build-database-ci-action@v3.3
         with:
@@ -299,6 +292,13 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
         env:
           DOTNET_INSTALL_DIR: './.dotnet'
+
+      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
+      # - name: Authenticate with GitHub Packages
+      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
+      #   with:
+      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
+      #     orgs: ''
 
       - name: dotnet build
         id: build
@@ -541,19 +541,19 @@ jobs:
         working-directory: '.' # TODO:  Update if package-lock.json is not at the root of the project
         run: npm rebuild
 
-      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
-      # - name: Authenticate with GitHub Packages
-      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
-      #   with:
-      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
-      #     orgs: ''
-
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
         env:
           DOTNET_INSTALL_DIR: './.dotnet'
+
+      # TODO:  If the project contains internal nuget packages, uncomment and update the orgs with the needed organizations
+      # - name: Authenticate with GitHub Packages
+      #   uses: im-open/authenticate-with-gh-package-registries@v1.1
+      #   with:
+      #     read-pkg-token: ${{ secrets.READ_PKG_TOKEN }} # This is an org-level secret
+      #     orgs: ''
 
       # TODO: If the project being built publishes to Azure Event Hubs, this step is needed to build an AsyncAPI Document.
       #       It runs a console application that calls the Mktp.Messaging.Events.Publisher.AsyncApi library.


### PR DESCRIPTION
While removing the Artifactory entry from **nuget.config**, I realized our .NET CI workflow template needs to include an “Authenticate with GitHub Packages” step to both the `dotnet-test` and `build-deployment-artifacts` jobs. This is required whenever a .NET app uses an internal NuGet package like the Mktp.Api.Authentication package (v2.1.14).

**Note**: I used PR [PR #251](https://github.com/im-customer-engagement/cep-case-comments/pull/251) to verify these changes.